### PR TITLE
Add hook for receiving stream RST error.

### DIFF
--- a/lib/src/streams/stream_handler.dart
+++ b/lib/src/streams/stream_handler.dart
@@ -103,14 +103,14 @@ class Http2StreamImpl extends TransportStream
 
   void terminate() => _terminateStreamFun(this);
 
-  set onTerminated(void Function(int) handler) {
+  set onTerminated(void handler(int)) {
     _onTerminated = handler;
     if (_terminatedErrorCode != null && _onTerminated != null) {
       _onTerminated(_terminatedErrorCode);
     }
   }
 
-  set terminatedErrorCode(int errorCode) {
+  void _handleTerminated(int errorCode) {
     _terminatedErrorCode = errorCode;
     if (_onTerminated != null) {
       _onTerminated(_terminatedErrorCode);
@@ -618,7 +618,7 @@ class StreamHandler extends Object with TerminatableMixin, ClosableMixin {
   }
 
   void _handleRstFrame(Http2StreamImpl stream, RstStreamFrame frame) {
-    stream.terminatedErrorCode = frame.errorCode;
+    stream._handleTerminated(frame.errorCode);
     var exception = new StreamException(
         stream.id, 'Stream was terminated by peer.');
     _closeStreamAbnormally(stream, exception, propagateException: true);

--- a/lib/src/streams/stream_handler.dart
+++ b/lib/src/streams/stream_handler.dart
@@ -110,7 +110,7 @@ class Http2StreamImpl extends TransportStream
     }
   }
 
-  set cancelErrorCode(int errorCode) {
+  set terminatedErrorCode(int errorCode) {
     _terminatedErrorCode = errorCode;
     if (_onTerminated != null) {
       _onTerminated(_terminatedErrorCode);
@@ -618,7 +618,7 @@ class StreamHandler extends Object with TerminatableMixin, ClosableMixin {
   }
 
   void _handleRstFrame(Http2StreamImpl stream, RstStreamFrame frame) {
-    stream.cancelErrorCode = frame.errorCode;
+    stream.terminatedErrorCode = frame.errorCode;
     var exception = new StreamException(
         stream.id, 'Stream was terminated by peer.');
     _closeStreamAbnormally(stream, exception, propagateException: true);

--- a/lib/src/streams/stream_handler.dart
+++ b/lib/src/streams/stream_handler.dart
@@ -61,9 +61,12 @@ class Http2StreamImpl extends TransportStream
   // The state of this stream.
   StreamState state = StreamState.Idle;
 
-  int _cancelErrorCode;
+  // Error code from RST_STREAM frame, if the stream has been terminated
+  // remotely.
+  int _terminatedErrorCode;
 
-  void Function(int) _onCancel;
+  // Termination handler. Invoked if the stream receives an RST_STREAM frame.
+  void Function(int) _onTerminated;
 
   final Function _canPushFun;
   final Function _pushStreamFun;
@@ -100,17 +103,17 @@ class Http2StreamImpl extends TransportStream
 
   void terminate() => _terminateStreamFun(this);
 
-  void onCancel(void handler(int)) {
-    _onCancel = handler;
-    if (_cancelErrorCode != null && _onCancel != null) {
-      _onCancel(_cancelErrorCode);
+  set onTerminated(void Function(int) handler) {
+    _onTerminated = handler;
+    if (_terminatedErrorCode != null && _onTerminated != null) {
+      _onTerminated(_terminatedErrorCode);
     }
   }
 
   set cancelErrorCode(int errorCode) {
-    _cancelErrorCode = errorCode;
-    if (_onCancel != null) {
-      _onCancel(_cancelErrorCode);
+    _terminatedErrorCode = errorCode;
+    if (_onTerminated != null) {
+      _onTerminated(_terminatedErrorCode);
     }
   }
 }

--- a/lib/transport.dart
+++ b/lib/transport.dart
@@ -210,6 +210,11 @@ abstract class TransportStream {
   /// A sink for writing data and/or headers to the remote end.
   StreamSink<StreamMessage> get outgoingMessages;
 
+  /// Set the cancellation handler on this stream.
+  ///
+  /// The handler will be called if the stream receives an RST_STREAM frame.
+  void onCancel(void value(int errorCode));
+
   /// Terminates this HTTP/2 stream in an un-normal way.
   ///
   /// For normal termination, one can cancel the [StreamSubscription] from

--- a/lib/transport.dart
+++ b/lib/transport.dart
@@ -210,10 +210,10 @@ abstract class TransportStream {
   /// A sink for writing data and/or headers to the remote end.
   StreamSink<StreamMessage> get outgoingMessages;
 
-  /// Set the cancellation handler on this stream.
+  /// Set the termination handler on this stream.
   ///
   /// The handler will be called if the stream receives an RST_STREAM frame.
-  void onCancel(void value(int errorCode));
+  set onTerminated(void Function(int) value);
 
   /// Terminates this HTTP/2 stream in an un-normal way.
   ///

--- a/lib/transport.dart
+++ b/lib/transport.dart
@@ -213,7 +213,7 @@ abstract class TransportStream {
   /// Set the termination handler on this stream.
   ///
   /// The handler will be called if the stream receives an RST_STREAM frame.
-  set onTerminated(void Function(int) value);
+  set onTerminated(void value(int));
 
   /// Terminates this HTTP/2 stream in an un-normal way.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/http2
 
 environment:
-  sdk: '>=1.13.0-dev.1 <2.0.0'
+  sdk: '>=1.24.0-dev.6.7 <2.0.0'
 
 dev_dependencies:
   test: '>=0.12.0 <0.13.0'

--- a/test/transport_test.dart
+++ b/test/transport_test.dart
@@ -262,6 +262,41 @@ main() {
       await Future.wait([serverFun(), clientFun()]);
     });
 
+    transportTest('server-terminates-stream-after-half-close',
+        (ClientTransportConnection client,
+         ServerTransportConnection server) async {
+
+          var readyForError = new Completer();
+
+          Future serverFun() async {
+            await for (ServerTransportStream stream in server.incomingStreams) {
+              stream.sendHeaders([new Header.ascii('x', 'y')], endStream: false);
+              stream.incomingMessages.listen(
+                expectAsync1((msg) async {
+                  expect(msg is HeadersStreamMessage, true);
+                  await readyForError.future;
+                  stream.terminate();
+                }),
+                onError: expectAsync1((_) {}, count: 0),
+                onDone: expectAsync0(() {}, count: 1),
+              );
+            }
+            await server.finish();
+          }
+
+          Future clientFun() async {
+            var headers = [new Header.ascii('a', 'b')];
+            var stream = client.makeRequest(headers, endStream: false);
+            stream.onTerminated = expectAsync1((errorCode) {
+              expect(errorCode, 8);
+            }, count: 1);
+            readyForError.complete();
+            await client.finish();
+          }
+
+          await Future.wait([serverFun(), clientFun()]);
+        });
+
     group('flow-control', () {
       const int kChunkSize = 1024;
       const int kNumberOfMessages = 1000;

--- a/test/transport_test.dart
+++ b/test/transport_test.dart
@@ -233,9 +233,9 @@ main() {
 
       Future serverFun() async {
         await for (ServerTransportStream stream in server.incomingStreams) {
-          stream.onCancel(expectAsync1((errorCode) {
+          stream.onTerminated = expectAsync1((errorCode) {
             expect(errorCode, 8);
-          }, count: 1));
+          }, count: 1);
           stream.sendHeaders([new Header.ascii('x', 'y')], endStream: false);
           stream.incomingMessages.listen(
             expectAsync1((msg) {


### PR DESCRIPTION
Normally, a stream RST is delivered as an error on the incoming stream,
but if the incoming stream has already been consumed, there is no good
way to detect that the stream has been terminated.

Added a `onTerminated` hook, allowing user code to register a callback that
is invoked when a RST frame is received. The gRPC code uses this to
detect when a call has been canceled.