### PR TITLE
Fix hints and lints.

### DIFF
--- a/lib/src/artificial_server_socket.dart
+++ b/lib/src/artificial_server_socket.dart
@@ -28,9 +28,6 @@ class ArtificialServerSocket extends Object
 
   final int port;
 
-  @deprecated
-  ServerSocketReference get reference => null;
-
   /// Closing of an [ArtificialServerSocket] is not possible and an exception
   /// will be thrown when calling this method.
   Future<ServerSocket> close() async {

--- a/manual_test/out_of_stream_ids_test.dart
+++ b/manual_test/out_of_stream_ids_test.dart
@@ -42,7 +42,8 @@ main() {
         }
 
         expect(client.isOpen, false);
-        expect(() => client.makeRequest(headers), throws);
+        expect(() => client.makeRequest(headers),
+            throwsA(new isInstanceOf<StateError>()));
 
         await new Future.delayed(const Duration(seconds: 1));
         await client.finish();

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -398,8 +398,8 @@ main() {
 
           var stream = client.makeRequest([new Header.ascii('a', 'b')]);
           var sub = stream.incomingMessages.listen(
-              expectAsync((StreamMessage msg) {}, count: 0),
-              onError: expectAsync((error) {}));
+              expectAsync1((StreamMessage msg) {}, count: 0),
+              onError: expectAsync1((error) {}));
           sub.pause();
           await new Future.delayed(const Duration(milliseconds: 40));
           sub.resume();
@@ -517,7 +517,7 @@ main() {
               [new Header.ascii('a', 'b')], endStream: false);
 
           // Make sure we don't get messages/pushes on the terminated stream.
-          stream.incomingMessages.toList().catchError(expectAsync((e) {
+          stream.incomingMessages.toList().catchError(expectAsync1((e) {
             expect('$e', contains('This stream was not processed and can '
                                   'therefore be retried'));
           }));

--- a/test/multiprotocol_server_test.dart
+++ b/test/multiprotocol_server_test.dart
@@ -26,13 +26,13 @@ main() {
       var server = await MultiProtocolHttpServer.bind('localhost', 0, context);
       int requestNr = 0;
       server.startServing(
-          expectAsync((HttpRequest request) async {
+          expectAsync1((HttpRequest request) async {
             await handleHttp11Request(request, requestNr++);
             if (requestNr == Count) {
               await server.close();
             }
           }, count: Count),
-          expectAsync((ServerTransportStream stream) {
+          expectAsync1((ServerTransportStream stream) {
           }, count: 0));
 
       var client = new HttpClient();
@@ -50,9 +50,9 @@ main() {
       var server = await MultiProtocolHttpServer.bind('localhost', 0, context);
       int requestNr = 0;
       server.startServing(
-          expectAsync((HttpRequest request) {
+          expectAsync1((HttpRequest request) {
           }, count: 0),
-          expectAsync((ServerTransportStream stream) async {
+          expectAsync1((ServerTransportStream stream) async {
             await handleHttp2Request(stream, requestNr++);
             if (requestNr == Count) {
               await server.close();

--- a/test/src/async_utils/async_utils_test.dart
+++ b/test/src/async_utils/async_utils_test.dart
@@ -11,7 +11,7 @@ main() {
   group('async_utils', () {
     test('buffer-indicator', () {
       var bi = new BufferIndicator();
-      bi.bufferEmptyEvents.listen(expectAsync((_) {}, count: 2));
+      bi.bufferEmptyEvents.listen(expectAsync1((_) {}, count: 2));
 
       expect(bi.wouldBuffer, true);
 
@@ -39,21 +39,21 @@ main() {
       var bs = new BufferedSink(c);
 
       expect(bs.bufferIndicator.wouldBuffer, true);
-      var sub = c.stream.listen(expectAsync((_) {}, count: 2));
+      var sub = c.stream.listen(expectAsync1((_) {}, count: 2));
 
       expect(bs.bufferIndicator.wouldBuffer, false);
 
       sub.pause();
-      Timer.run(expectAsync(() {
+      Timer.run(expectAsync0(() {
         expect(bs.bufferIndicator.wouldBuffer, true);
         bs.sink.add([1]);
 
         sub.resume();
-        Timer.run(expectAsync(() {
+        Timer.run(expectAsync0(() {
           expect(bs.bufferIndicator.wouldBuffer, false);
           bs.sink.add([2]);
 
-          Timer.run(expectAsync(() {
+          Timer.run(expectAsync0(() {
             sub.cancel();
             expect(bs.bufferIndicator.wouldBuffer, false);
           }));

--- a/test/src/connection_preface_test.dart
+++ b/test/src/connection_preface_test.dart
@@ -43,7 +43,7 @@ main() {
       }
       c.close();
 
-      resultF.catchError(expectAsync((error, _) {
+      resultF.catchError(expectAsync2((error, _) {
         expect(error, contains('EOS before connection preface could be read'));
       }));
     });
@@ -58,7 +58,7 @@ main() {
       }
       c.close();
 
-      resultF.catchError(expectAsync((error, _) {
+      resultF.catchError(expectAsync2((error, _) {
         expect(error, contains('Connection preface does not match.'));
       }));
     });
@@ -71,7 +71,7 @@ main() {
       c.addError('hello world');
       c.close();
 
-      resultF.catchError(expectAsync((error, _) {
+      resultF.catchError(expectAsync2((error, _) {
         expect(error, contains('hello world'));
       }));
     });

--- a/test/src/error_matchers.dart
+++ b/test/src/error_matchers.dart
@@ -14,9 +14,6 @@ class _ProtocolException extends TypeMatcher {
   bool matches(item, Map matchState) => item is ProtocolException;
 }
 
-const Matcher throwsProtocolException =
-    const Throws(isProtocolException);
-
 
 const Matcher isFrameSizeException = const _FrameSizeException();
 
@@ -24,9 +21,6 @@ class _FrameSizeException extends TypeMatcher {
   const _FrameSizeException() : super("FrameSizeException");
   bool matches(item, Map matchState) => item is FrameSizeException;
 }
-
-const Matcher throwsFrameSizeException =
-    const Throws(isFrameSizeException);
 
 
 const Matcher isTerminatedException = const _TerminatedException();
@@ -36,9 +30,6 @@ class _TerminatedException extends TypeMatcher {
   bool matches(item, Map matchState) => item is TerminatedException;
 }
 
-const Matcher throwsTerminatedException =
-    const Throws(isTerminatedException);
-
 
 const Matcher isFlowControlException = const _FlowControlException();
 
@@ -46,6 +37,3 @@ class _FlowControlException extends TypeMatcher {
   const _FlowControlException() : super("FlowControlException");
   bool matches(item, Map matchState) => item is FlowControlException;
 }
-
-const Matcher throwsFlowControlException =
-    const Throws(isFlowControlException);

--- a/test/src/flowcontrol/connection_queues_test.dart
+++ b/test/src/flowcontrol/connection_queues_test.dart
@@ -101,10 +101,10 @@ main() {
       windowMock.positiveWindow.markUnBuffered();
 
       queue.startClosing();
-      queue.done.then(expectAsync((_) {
+      queue.done.then(expectAsync1((_) {
         expect(queue.pendingMessages, 0);
         expect(() => queue.enqueueMessage(new DataMessage(99, bytes, true)),
-               throws);
+               throwsA(new isInstanceOf<StateError>()));
       }));
     });
 
@@ -171,27 +171,19 @@ main() {
 
 class MockFrameWriter extends SmartMock implements FrameWriter {
   BufferIndicator bufferIndicator = new BufferIndicator();
-
-  dynamic noSuchMethod(_) => super.noSuchMethod(_);
 }
 
 class MockStreamMessageQueueIn extends SmartMock
                                implements StreamMessageQueueIn {
   BufferIndicator bufferIndicator = new BufferIndicator();
-
-  dynamic noSuchMethod(_) => super.noSuchMethod(_);
 }
 
 class MockIncomingWindowHandler extends SmartMock
-                                implements IncomingWindowHandler {
-  dynamic noSuchMethod(_) => super.noSuchMethod(_);
-}
+                                implements IncomingWindowHandler { }
 
 class MockOutgoingWindowHandler extends SmartMock
                                 implements OutgoingConnectionWindowHandler,
                                            OutgoingStreamWindowHandler {
   BufferIndicator positiveWindow = new BufferIndicator();
   int peerWindowSize = new Window().size;
-
-  dynamic noSuchMethod(_) => super.noSuchMethod(_);
 }

--- a/test/src/flowcontrol/window_handler_test.dart
+++ b/test/src/flowcontrol/window_handler_test.dart
@@ -18,7 +18,7 @@ main() {
         Window window,
         int initialSize) {
       var sub = handler.positiveWindow.bufferEmptyEvents.listen(
-          expectAsync((_) {}, count: 0));
+          expectAsync1((_) {}, count: 0));
 
       expect(handler.peerWindowSize, initialSize);
       expect(window.size, initialSize);
@@ -43,7 +43,7 @@ main() {
       expect(handler.positiveWindow.wouldBuffer, isFalse);
       handler.decreaseWindow(window.size);
       expect(handler.positiveWindow.wouldBuffer, isTrue);
-      sub = handler.positiveWindow.bufferEmptyEvents.listen(expectAsync((_) {
+      sub = handler.positiveWindow.bufferEmptyEvents.listen(expectAsync1((_) {
         expect(handler.peerWindowSize, 1);
         expect(window.size, 1);
       }));
@@ -84,7 +84,7 @@ main() {
 
       expect(handler.positiveWindow.wouldBuffer, isFalse);
       handler.positiveWindow.bufferEmptyEvents.listen(
-          expectAsync((_) {}, count: 0));
+          expectAsync1((_) {}, count: 0));
       handler.processInitialWindowSizeSettingChange(-window.size);
       expect(handler.positiveWindow.wouldBuffer, isTrue);
       expect(handler.peerWindowSize, 0);
@@ -128,6 +128,4 @@ main() {
   });
 }
 
-class FrameWriterMock extends SmartMock implements FrameWriter {
-  dynamic noSuchMethod(_) => super.noSuchMethod(_);
-}
+class FrameWriterMock extends SmartMock implements FrameWriter { }

--- a/test/src/frames/frame_defragmenter_test.dart
+++ b/test/src/frames/frame_defragmenter_test.dart
@@ -88,7 +88,7 @@ main() {
 
         expect(defrag.tryDefragmentFrame(f1), isNull);
         expect(() => defrag.tryDefragmentFrame(f2),
-               throwsProtocolException);
+               throwsA(isProtocolException));
       });
 
       test('fragmented-push-promise-frame', () {
@@ -99,7 +99,7 @@ main() {
 
         expect(defrag.tryDefragmentFrame(f1), isNull);
         expect(() => defrag.tryDefragmentFrame(f2),
-               throwsProtocolException);
+               throwsA(isProtocolException));
       });
 
       test('fragmented-headers-frame--no-continuation-frame', () {
@@ -110,7 +110,7 @@ main() {
 
         expect(defrag.tryDefragmentFrame(f1), isNull);
         expect(() => defrag.tryDefragmentFrame(f2),
-               throwsProtocolException);
+               throwsA(isProtocolException));
       });
 
       test('fragmented-push-promise-no-continuation-frame', () {
@@ -121,7 +121,7 @@ main() {
 
         expect(defrag.tryDefragmentFrame(f1), isNull);
         expect(() => defrag.tryDefragmentFrame(f2),
-               throwsProtocolException);
+               throwsA(isProtocolException));
       });
 
       test('push-without-headres-or-push-promise-frame', () {

--- a/test/src/frames/frame_writer_reader_test.dart
+++ b/test/src/frames/frame_writer_reader_test.dart
@@ -12,8 +12,6 @@ import 'package:http2/src/settings/settings.dart';
 
 import '../hpack/hpack_test.dart' show isHeader;
 
-import '../error_matchers.dart';
-
 main() {
   group('frames', () {
     group('writer-reader', () {

--- a/test/src/frames/frame_writer_test.dart
+++ b/test/src/frames/frame_writer_test.dart
@@ -19,7 +19,7 @@ main() {
         var controller = new StreamController<List<int>>();
         var writer = new FrameWriter(context.encoder, controller, settings);
 
-        writer.doneFuture.then(expectAsync((_) {
+        writer.doneFuture.then(expectAsync1((_) {
           // We expect that the writer is done at this point.
         }));
 

--- a/test/src/hpack/hpack_test.dart
+++ b/test/src/hpack/hpack_test.dart
@@ -184,19 +184,19 @@ main() {
       test('invalid-integer-encoding', () {
         var context = new HPackContext();
         expect(() => context.decoder.decode([1 << 6, 0xff]),
-               throwsHuffmanDecodingException);
+               throwsA(isHPackDecodingException));
       });
 
       test('index-out-of-table-size', () {
         var context = new HPackContext();
         expect(() => context.decoder.decode([0x7f]),
-               throwsHuffmanDecodingException);
+               throwsA(isHPackDecodingException));
       });
 
       test('invalid-update-dynamic-table-size', () {
         var context = new HPackContext();
         expect(() => context.decoder.decode([0x3f]),
-               throwsHuffmanDecodingException);
+               throwsA(isHPackDecodingException));
       });
 
       test('update-dynamic-table-size-too-high', () {
@@ -204,7 +204,7 @@ main() {
         // Tries to set dynamic table to 4097 (max is 4096 by default)
         var bytes = TestHelper.newInteger(0x20, 5, 4097);
         expect(() => context.decoder.decode(bytes),
-               throwsHuffmanDecodingException);
+               throwsA(isHPackDecodingException));
       });
     });
 
@@ -419,11 +419,6 @@ class _HPackDecodingException extends TypeMatcher {
   const _HPackDecodingException() : super("HPackDecodingException");
   bool matches(item, Map matchState) => item is HPackDecodingException;
 }
-
-const Matcher throwsHuffmanDecodingException =
-    const Throws(isHPackDecodingException);
-
-
 
 class _HeaderMatcher extends Matcher {
   final Header header;

--- a/test/src/hpack/huffman_table_test.dart
+++ b/test/src/hpack/huffman_table_test.dart
@@ -49,7 +49,7 @@ main() {
         ];
 
         for (var test in data) {
-          expect(() => decode(test), throwsHuffmanDecodingException);
+          expect(() => decode(test), throwsA(isHuffmanDecodingException));
         }
       });
 
@@ -63,7 +63,7 @@ main() {
         ];
 
         for (var test in data) {
-          expect(() => decode(test), throwsHuffmanDecodingException);
+          expect(() => decode(test), throwsA(isHuffmanDecodingException));
         }
       });
 
@@ -150,6 +150,3 @@ class _HuffmanDecodingException extends TypeMatcher {
   const _HuffmanDecodingException() : super("HuffmanDecodingException");
   bool matches(item, Map matchState) => item is HuffmanDecodingException;
 }
-
-const Matcher throwsHuffmanDecodingException =
-    const Throws(isHuffmanDecodingException);

--- a/test/src/mock_utils.dart
+++ b/test/src/mock_utils.dart
@@ -77,7 +77,7 @@ class SmartMock {
 /// arguments
 /// (e.g. `expectAsync((List<Setting> settings, {bool ack: true}) {})`).
 class TestCounter {
-  final Function _complete = expectAsync(() {});
+  final Function _complete = expectAsync0(() {});
 
   final int count;
   int _got = 0;

--- a/test/src/ping/ping_handler_test.dart
+++ b/test/src/ping/ping_handler_test.dart
@@ -72,11 +72,11 @@ main() {
 
       var header = new FrameHeader(8, FrameType.PING, PingFrame.FLAG_ACK, 0);
       expect(() => pingHandler.processPingFrame(new PingFrame(header, 2)),
-             throwsProtocolException);
+             throwsA(isProtocolException));
 
       // Ensure outstanding pings will be completed with an error once we call
       // `pingHandler.terminate()`.
-      future.catchError(expectAsync((error, _) {
+      future.catchError(expectAsync2((error, _) {
         expect(error, 'hello world');
       }));
       pingHandler.terminate('hello world');
@@ -88,9 +88,9 @@ main() {
 
       pingHandler.terminate('hello world');
       expect(() => pingHandler.processPingFrame(null),
-             throwsTerminatedException);
+             throwsA(isTerminatedException));
       expect(pingHandler.ping(),
-             throwsTerminatedException);
+             throwsA(isTerminatedException));
     });
 
     test('ping-non-zero-stream-id', () async {
@@ -99,11 +99,9 @@ main() {
 
       var header = new FrameHeader(8, FrameType.PING, PingFrame.FLAG_ACK, 1);
       expect(() => pingHandler.processPingFrame(new PingFrame(header, 1)),
-             throwsProtocolException);
+             throwsA(isProtocolException));
     });
   });
 }
 
-class FrameWriterMock extends SmartMock implements FrameWriter {
-  dynamic noSuchMethod(_) => super.noSuchMethod(_);
-}
+class FrameWriterMock extends SmartMock implements FrameWriter { }

--- a/test/src/settings/settings_handler_test.dart
+++ b/test/src/settings/settings_handler_test.dart
@@ -83,7 +83,7 @@ main() {
       var settingsFrame = new SettingsFrame(header, const []);
 
       expect(() => sh.handleSettingsFrame(settingsFrame),
-             throwsProtocolException);
+             throwsA(isProtocolException));
     });
 
     test('invalid-remote-settings-change', () {
@@ -99,7 +99,7 @@ main() {
       var header = new FrameHeader(6, FrameType.SETTINGS, 0, 0);
       var settingsFrame = new SettingsFrame(header, invalidPushSettings);
       expect(() => sh.handleSettingsFrame(settingsFrame),
-             throwsProtocolException);
+             throwsA(isProtocolException));
     });
 
     test('change-max-header-table-size', () {
@@ -112,19 +112,15 @@ main() {
       // Simulate remote end by setting the push setting.
       var header = new FrameHeader(6, FrameType.SETTINGS, 0, 0);
       var settingsFrame = new SettingsFrame(header, setMaxTable256);
-      mock.mock_updateMaxSendingHeaderTableSize = expectAsync((int newSize) {
+      mock.mock_updateMaxSendingHeaderTableSize = expectAsync1((int newSize) {
         expect(newSize, 256);
       });
-      writer.mock_writeSettingsAckFrame = expectAsync(() { });
+      writer.mock_writeSettingsAckFrame = expectAsync0(() { });
       sh.handleSettingsFrame(settingsFrame);
     });
   });
 }
 
-class FrameWriterMock extends SmartMock implements FrameWriter {
-  dynamic noSuchMethod(_) => super.noSuchMethod(_);
-}
+class FrameWriterMock extends SmartMock implements FrameWriter { }
 
-class HPackEncoderMock extends SmartMock implements HPackEncoder {
-  dynamic noSuchMethod(_) => super.noSuchMethod(_);
-}
+class HPackEncoderMock extends SmartMock implements HPackEncoder { }

--- a/test/src/streams/helper.dart
+++ b/test/src/streams/helper.dart
@@ -10,7 +10,6 @@ import 'package:test/test.dart';
 
 import 'package:http2/transport.dart';
 import 'package:http2/src/frames/frames.dart';
-import 'package:http2/src/connection.dart';
 import 'package:http2/src/settings/settings.dart';
 
 expectHeadersEqual(List<Header> headers, List<Header> expectedHeaders) {
@@ -22,7 +21,7 @@ expectHeadersEqual(List<Header> headers, List<Header> expectedHeaders) {
 }
 
 expectEmptyStream(Stream s) {
-  s.listen(expectAsync((_) {}, count: 0), onDone: expectAsync(() {}));
+  s.listen(expectAsync1((_) {}, count: 0), onDone: expectAsync0(() {}));
 }
 
 streamTest(String name, func(client, server), {ClientSettings settings}) {

--- a/test/src/streams/simple_flow_test.dart
+++ b/test/src/streams/simple_flow_test.dart
@@ -21,7 +21,7 @@ main() {
       allBytes.addAll(new List.generate(42, (i) => 42));
 
       headersTestFun(String type) {
-        return expectAsync((StreamMessage msg) {
+        return expectAsync1((StreamMessage msg) {
           expect(msg is HeadersStreamMessage, isTrue);
           expect((msg as HeadersStreamMessage).headers.first.name,
                  expectedHeaders.first.name);
@@ -75,9 +75,9 @@ main() {
           (ClientTransportConnection client,
            ServerTransportConnection server) async {
         server.incomingStreams.listen(
-            expectAsync((TransportStream sStream) async {
+            expectAsync1((TransportStream sStream) async {
           sStream.incomingMessages.listen(
-              messageTestFun('server'), onDone: expectAsync(() { }));
+              messageTestFun('server'), onDone: expectAsync0(() { }));
           sStream.sendHeaders(expectedHeaders, endStream: true);
           expect(await serverReceivedAllBytes.future, completes);
         }));
@@ -85,7 +85,7 @@ main() {
         TransportStream cStream = client.makeRequest(expectedHeaders);
         sendData(cStream);
         cStream.incomingMessages.listen(
-            headersTestFun('client'), onDone: expectAsync(() {}));
+            headersTestFun('client'), onDone: expectAsync0(() {}));
       });
     });
   });

--- a/test/src/streams/simple_push_test.dart
+++ b/test/src/streams/simple_push_test.dart
@@ -30,7 +30,7 @@ main() {
       }
 
       headersTestFun() {
-        return expectAsync((StreamMessage msg) {
+        return expectAsync1((StreamMessage msg) {
           expect(msg is HeadersStreamMessage, isTrue);
           testHeaders((msg as HeadersStreamMessage).headers);
         });
@@ -62,7 +62,7 @@ main() {
           (ClientTransportConnection client,
            ServerTransportConnection server) async {
         server.incomingStreams.listen(
-            expectAsync((ServerTransportStream sStream) async {
+            expectAsync1((ServerTransportStream sStream) async {
           var pushStream = sStream.push(expectedHeaders);
           pushStream.sendHeaders(expectedHeaders);
           await sendData(pushStream, 'pushing "hello world" :)');
@@ -76,8 +76,8 @@ main() {
         ClientTransportStream cStream =
             client.makeRequest(expectedHeaders, endStream: true);
         cStream.incomingMessages.listen(
-            headersTestFun(), onDone: expectAsync(() { }));
-        cStream.peerPushes.listen(expectAsync((TransportStreamPush push) async {
+            headersTestFun(), onDone: expectAsync0(() { }));
+        cStream.peerPushes.listen(expectAsync1((TransportStreamPush push) async {
           testHeaders(push.requestHeaders);
 
           var iterator = new StreamIterator(push.stream.incomingMessages);

--- a/test/src/streams/streams_test.dart
+++ b/test/src/streams/streams_test.dart
@@ -16,13 +16,13 @@ main() {
                 ServerTransportConnection server) async {
       var expectedHeaders = [new Header.ascii('key', 'value')];
 
-      server.incomingStreams.listen(expectAsync((TransportStream sStream) {
-        sStream.incomingMessages.listen(expectAsync((StreamMessage msg) {
+      server.incomingStreams.listen(expectAsync1((TransportStream sStream) {
+        sStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
           expect(msg is HeadersStreamMessage, isTrue);
 
           HeadersStreamMessage headersMsg = msg;
           expectHeadersEqual(headersMsg.headers, expectedHeaders);
-        }), onDone: expectAsync(() {}));
+        }), onDone: expectAsync0(() {}));
         sStream.outgoingMessages.close();
       }));
 
@@ -36,13 +36,13 @@ main() {
                 ServerTransportConnection server) async {
       var expectedHeaders = [new Header.ascii('key', 'value')];
 
-      server.incomingStreams.listen(expectAsync((TransportStream sStream) {
-        sStream.incomingMessages.listen(expectAsync((StreamMessage msg) {
+      server.incomingStreams.listen(expectAsync1((TransportStream sStream) {
+        sStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
           expect(msg is HeadersStreamMessage, isTrue);
 
           HeadersStreamMessage headersMsg = msg;
           expectHeadersEqual(headersMsg.headers, expectedHeaders);
-        }, count: 3), onDone: expectAsync(() {}));
+        }, count: 3), onDone: expectAsync0(() {}));
         sStream.outgoingMessages.close();
       }));
 
@@ -59,10 +59,10 @@ main() {
       var chunks = [[1], [2], [3]];
 
       server.incomingStreams.listen(
-          expectAsync((TransportStream sStream) async {
+          expectAsync1((TransportStream sStream) async {
         bool isFirst = true;
         var receivedChunks = [];
-        sStream.incomingMessages.listen(expectAsync((StreamMessage msg) {
+        sStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
           if (isFirst) {
             isFirst = false;
             expect(msg is HeadersStreamMessage, isTrue);
@@ -75,7 +75,7 @@ main() {
             DataStreamMessage dataMsg = msg;
             receivedChunks.add(dataMsg.bytes);
           }
-        }, count: 1 + chunks.length), onDone: expectAsync(() {
+        }, count: 1 + chunks.length), onDone: expectAsync0(() {
           expect(receivedChunks, chunks);
         }));
         sStream.outgoingMessages.close();
@@ -92,25 +92,25 @@ main() {
                 ServerTransportConnection server) async {
       var expectedHeaders = [new Header.ascii('key', 'value')];
 
-      server.incomingStreams.listen(expectAsync((TransportStream sStream) {
-        sStream.incomingMessages.listen(expectAsync((StreamMessage msg) {
+      server.incomingStreams.listen(expectAsync1((TransportStream sStream) {
+        sStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
           expect(msg is HeadersStreamMessage, isTrue);
 
           HeadersStreamMessage headersMsg = msg;
           expectHeadersEqual(headersMsg.headers, expectedHeaders);
-        }), onDone: expectAsync(() {}));
+        }), onDone: expectAsync0(() {}));
         sStream.sendHeaders(expectedHeaders, endStream: true);
       }));
 
       TransportStream cStream =
           client.makeRequest(expectedHeaders, endStream: true);
 
-      cStream.incomingMessages.listen(expectAsync((StreamMessage msg) {
+      cStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
         expect(msg is HeadersStreamMessage, isTrue);
 
         HeadersStreamMessage headersMsg = msg;
         expectHeadersEqual(headersMsg.headers, expectedHeaders);
-      }), onDone: expectAsync(() {}));
+      }), onDone: expectAsync0(() {}));
     });
 
     streamTest('single-header-request--multi-headers-response',
@@ -118,13 +118,13 @@ main() {
                 ServerTransportConnection server) async {
       var expectedHeaders = [new Header.ascii('key', 'value')];
 
-      server.incomingStreams.listen(expectAsync((TransportStream sStream) {
-        sStream.incomingMessages.listen(expectAsync((StreamMessage msg) {
+      server.incomingStreams.listen(expectAsync1((TransportStream sStream) {
+        sStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
           expect(msg is HeadersStreamMessage, isTrue);
 
           HeadersStreamMessage headersMsg = msg;
           expectHeadersEqual(headersMsg.headers, expectedHeaders);
-        }), onDone: expectAsync(() {}));
+        }), onDone: expectAsync0(() {}));
 
         sStream.sendHeaders(expectedHeaders);
         sStream.sendHeaders(expectedHeaders);
@@ -134,7 +134,7 @@ main() {
       TransportStream cStream =
           client.makeRequest(expectedHeaders, endStream: true);
 
-      cStream.incomingMessages.listen(expectAsync((StreamMessage msg) {
+      cStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
         expect(msg is HeadersStreamMessage, isTrue);
 
         HeadersStreamMessage headersMsg = msg;
@@ -148,13 +148,13 @@ main() {
       var expectedHeaders = [new Header.ascii('key', 'value')];
       var chunks = [[1], [2], [3]];
 
-      server.incomingStreams.listen(expectAsync((TransportStream sStream) {
-        sStream.incomingMessages.listen(expectAsync((StreamMessage msg) {
+      server.incomingStreams.listen(expectAsync1((TransportStream sStream) {
+        sStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
           expect(msg is HeadersStreamMessage, isTrue);
 
           HeadersStreamMessage headersMsg = msg;
           expectHeadersEqual(headersMsg.headers, expectedHeaders);
-        }), onDone: expectAsync(() {}));
+        }), onDone: expectAsync0(() {}));
 
         chunks.forEach(sStream.sendData);
         sStream.outgoingMessages.close();
@@ -164,7 +164,7 @@ main() {
       cStream.outgoingMessages.close();
 
       int i = 0;
-      cStream.incomingMessages.listen(expectAsync((StreamMessage msg) {
+      cStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
         expect(msg is DataStreamMessage, isTrue);
         expect((msg as DataStreamMessage).bytes, chunks[i++]);
       }, count: chunks.length));
@@ -177,11 +177,11 @@ main() {
     var expectedHeaders = [new Header.ascii('key', 'value')];
     var chunk = [1];
 
-    server.incomingStreams.listen(expectAsync((TransportStream sStream) async {
+    server.incomingStreams.listen(expectAsync1((TransportStream sStream) async {
       bool isFirst = true;
       var receivedChunk;
       sStream.incomingMessages.listen(
-          expectAsync((StreamMessage msg) {
+          expectAsync1((StreamMessage msg) {
             if (isFirst) {
               isFirst = false;
               expect(msg is HeadersStreamMessage, isTrue);
@@ -197,7 +197,7 @@ main() {
               DataStreamMessage dataMsg = msg;
               receivedChunk = dataMsg.bytes;
             }
-          }, count: 2), onDone: expectAsync(() {
+          }, count: 2), onDone: expectAsync0(() {
         expect(receivedChunk, chunk);
         sStream.sendData([2]);
         sStream.sendHeaders(expectedHeaders, endStream: true);
@@ -208,7 +208,7 @@ main() {
     cStream.sendData(chunk, endStream: true);
 
     bool isFirst = true;
-    cStream.incomingMessages.listen(expectAsync((StreamMessage msg) {
+    cStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
       if (isFirst) {
         expect(msg, new isInstanceOf<DataStreamMessage>());
         final data = msg as DataStreamMessage;


### PR DESCRIPTION
Mostly updating tests to no longer use deprecated methods. After this,
only two hints remain: One with a TODO, and one for default window size
which isn't used. I wasn't sure what to do about those, so I left them
for now.