### PR TITLE
Remove use of new Function syntax for onActiveStateChanged.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.5
+
+* Removed use of new `Function` syntax, since it isn't fully supported in Dart
+  1.24.
+
 ## 0.1.4
 
 * Added an `onActiveStateChanged` callback to `Connection`, which is invoked when

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -73,7 +73,7 @@ abstract class Connection {
   final bool isClientConnection;
 
   /// Active state handler for this connection.
-  void Function(bool isActive) onActiveStateChanged;
+  ActiveStateHandler onActiveStateChanged;
 
   /// The HPack context for this connection.
   final HPackContext _hpackContext = new HPackContext();

--- a/lib/src/streams/stream_handler.dart
+++ b/lib/src/streams/stream_handler.dart
@@ -149,7 +149,7 @@ class StreamHandler extends Object with TerminatableMixin, ClosableMixin {
 
   bool get ranOutOfStreamIds => _ranOutOfStreamIds();
 
-  final void Function(bool isActive) _onActiveStateChanged;
+  final ActiveStateHandler _onActiveStateChanged;
 
   StreamHandler._(
       this._frameWriter,
@@ -167,7 +167,7 @@ class StreamHandler extends Object with TerminatableMixin, ClosableMixin {
       ConnectionMessageQueueOut outgoingQueue,
       ActiveSettings peerSettings,
       ActiveSettings localSettings,
-      void Function(bool isActive) onActiveStateChanged) {
+      ActiveStateHandler onActiveStateChanged) {
     return new StreamHandler._(writer, incomingQueue, outgoingQueue,
         peerSettings, localSettings, onActiveStateChanged, 1, 0);
   }
@@ -178,7 +178,7 @@ class StreamHandler extends Object with TerminatableMixin, ClosableMixin {
       ConnectionMessageQueueOut outgoingQueue,
       ActiveSettings peerSettings,
       ActiveSettings localSettings,
-      void Function(bool isActive) onActiveStateChanged) {
+      ActiveStateHandler onActiveStateChanged) {
     return new StreamHandler._(writer, incomingQueue, outgoingQueue,
         peerSettings, localSettings, onActiveStateChanged, 2, -1);
   }

--- a/lib/transport.dart
+++ b/lib/transport.dart
@@ -106,6 +106,8 @@ import 'src/hpack/hpack.dart' show Header;
 
 export 'src/hpack/hpack.dart' show Header;
 
+typedef void ActiveStateHandler(bool isActive);
+
 /// Settings for a [TransportConnection].
 abstract class Settings {
   /// The maximum number of concurrent streams the remote end can open
@@ -152,7 +154,7 @@ abstract class TransportConnection {
   /// goes from 0 to 1 (the connection goes from idle to active), and with
   /// [false] when the number of active streams becomes 0 (the connection goes
   /// from active to idle).
-  set onActiveStateChanged(void Function(bool isActive) callback);
+  set onActiveStateChanged(ActiveStateHandler callback);
 
   /// Finish this connection.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http2
-version: 0.1.5-dev
+version: 0.1.5
 description: A HTTP/2 implementation in Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/http2


### PR DESCRIPTION
The new syntax isn't fully supported in 1.24, so switching back to good
old typedef.

Fixes #14.