### PR TITLE
Lower mockito dependency to 2.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,5 +8,5 @@ environment:
   sdk: '>=1.24.0 <2.0.0'
 
 dev_dependencies:
-  mockito: ^2.2.0
+  mockito: ^2.0.0
   test: '>=0.12.0 <0.13.0'


### PR DESCRIPTION
Mockito v2.2.0 has a SDK constraint that isn't compatible with bleeding edge Dart SDK. v2.0.0 looks fine, and we don't depend on anything new from 2.2.0 anyway.