### PR TITLE
Changes for landing https://github.com/dart-lang/sdk/issues/32161

### DIFF
--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -526,7 +526,7 @@ main() {
   });
 }
 
-clientTest(
+void clientTest(
     String name,
     Future<Null> func(
         ClientTransportConnection clientConnection,

--- a/test/server_test.dart
+++ b/test/server_test.dart
@@ -194,7 +194,7 @@ main() {
   });
 }
 
-serverTest(
+void serverTest(
     String name,
     func(ServerTransportConnection serverConnection, FrameWriter frameWriter,
         StreamIterator<Frame> frameReader, Future<Frame> readNext())) {

--- a/test/src/streams/helper.dart
+++ b/test/src/streams/helper.dart
@@ -24,7 +24,7 @@ expectEmptyStream(Stream s) {
   s.listen(expectAsync1((_) {}, count: 0), onDone: expectAsync0(() {}));
 }
 
-streamTest(String name,
+void streamTest(String name,
     func(ClientTransportConnection client, ServerTransportConnection server),
     {ClientSettings settings}) {
   return test(name, () {
@@ -36,7 +36,7 @@ streamTest(String name,
   });
 }
 
-framesTest(String name, func(frameWriter, frameStream)) {
+void framesTest(String name, func(frameWriter, frameStream)) {
   return test(name, () {
     var c = new StreamController<List<int>>();
     var fw = new FrameWriter(null, c, new ActiveSettings());

--- a/test/transport_test.dart
+++ b/test/transport_test.dart
@@ -469,7 +469,7 @@ main() {
   });
 }
 
-transportTest(String name,
+void transportTest(String name,
     func(ClientTransportConnection client, ServerTransportConnection server),
     {ClientSettings clientSettings, ServerSettings serverSettings}) {
   return test(name, () {


### PR DESCRIPTION
Add void declarations to methods with implicit dynamic returning void
values, which may be illegal in dart 2, but in either case, expresses
the current intent better.