### PR TITLE
Fixes #29 by queuing GOAWAY messages

### DIFF
--- a/lib/src/flowcontrol/connection_queues.dart
+++ b/lib/src/flowcontrol/connection_queues.dart
@@ -141,6 +141,10 @@ class ConnectionMessageQueueOut extends Object
             new DataMessage(message.streamId, tail, message.endStream);
         _messages.addFirst(tailMessage);
       }
+    } else if (message is GoawayMessage) {
+      _messages.removeFirst();
+      _frameWriter.writeGoawayFrame(
+          message.lastStreamId, message.errorCode, message.debugData);
     } else {
       throw new StateError(
           'Unexpected message in queue: ${message.runtimeType}');

--- a/lib/src/flowcontrol/queue_messages.dart
+++ b/lib/src/flowcontrol/queue_messages.dart
@@ -50,3 +50,15 @@ class PushPromiseMessage extends Message {
   String toString() => 'PushPromiseMessage(bytes: ${headers.length}, '
       'promisedStreamId: $promisedStreamId, endStream: $endStream)';
 }
+
+class GoawayMessage extends Message {
+  final int lastStreamId;
+  final int errorCode;
+  final List<int> debugData;
+
+  GoawayMessage(this.lastStreamId, this.errorCode, this.debugData)
+      : super(0, false);
+
+  String toString() => 'GoawayMessage(lastStreamId: ${lastStreamId}, '
+      'errorCode: ${errorCode}, debugData: ${debugData.length})';
+}


### PR DESCRIPTION
#29 appears to be caused by a race condition where calling finish() will immediately write a GOAWAY frame to the framewriter which can cause queued messages to be sent after the GOAWAY.
This PR fixes this issue by queuing the GOAWAYs as well, giving the queued up message a chance to clear our in order.

Tested:
  dart --sync-async test/transport_test.dart