### PR TITLE
Fill in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,42 @@
 # HTTP/2 for Dart
 
-Note: This is a work in progress and experimental.
+This library provides an http/2 interface on top of a bidirectional stream of bytes.
+The client and server sides can be created via `ClientTransportStream` and `ServerTransportStream`
+respectively.
+Both sides can be configured via settings (see `ClientSettings` and `ServerSettings`).
 
-See the [API docs][api] for more details and sample code.
+The settings will be communicated to the remote peer (if necessary) and will be valid during the
+entire lifetime of the connection.
+
+A http/2 transport allows a client to open a bidirectional stream (see
+`ClientTransportConnection.makeRequest`) and a server can open (or push) a unidirectional stream to
+the client via `ServerTransportStream.push`.
+
+In both cases (unidirectional and bidirectional stream), one can send headers and data to the other
+side (via `HeadersStreamMessage` and `DataStreamMessage`).
+
+These messages are ordered and will arrive in the same order as they were sent (data messages may be
+split up into multiple smaller chunks or might be combined).
+
+In the most common case, each direction will send one `HeadersStreamMessage` followed by zero or
+more `DataStreamMessage`s.
+
+Establishing a bidirectional stream of bytes to a server is up to the user of this library.
+There are 3 common ways to achive this
+
+* connect to a server via SSL and use the ALPN (SSL) protocol extension to negotiate with the server
+  to speak http/2 (the ALPN protocol identifier for http/2 is `h2`).
+* have prior knowledge about the server - i.e. know ahead of time that the server will speak http/2
+  via an unencrypted tcp connection
+* use a http/1.1 connection and upgrade it to http/2
+
+The first way is the most common way and can be done in Dart by using `dart:io`s secure socket
+implementation (by using a `SecurityContext` and including 'h2' in the list of protocols used for
+ALPN).
+
+For a simple example on how to connect to a http/2 capable server and requesting a resource see:
+[https://github.com/dart-lang/http2/blob/master/example/display_headers.dart].
+
 
 ## Features and bugs
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ implementation (by using a `SecurityContext` and including 'h2' in the list of p
 ALPN).
 
 For a simple example on how to connect to a http/2 capable server and requesting a resource see:
-[https://github.com/dart-lang/http2/blob/master/example/display_headers.dart].
+https://github.com/dart-lang/http2/blob/master/example/display_headers.dart.
 
 
 ## Features and bugs

--- a/README.md
+++ b/README.md
@@ -1,42 +1,57 @@
 # HTTP/2 for Dart
 
 This library provides an http/2 interface on top of a bidirectional stream of bytes.
-The client and server sides can be created via `ClientTransportStream` and `ServerTransportStream`
-respectively.
-Both sides can be configured via settings (see `ClientSettings` and `ServerSettings`).
 
-The settings will be communicated to the remote peer (if necessary) and will be valid during the
-entire lifetime of the connection.
+## Usage:
 
-A http/2 transport allows a client to open a bidirectional stream (see
-`ClientTransportConnection.makeRequest`) and a server can open (or push) a unidirectional stream to
-the client via `ServerTransportStream.push`.
+Here is a minimal example of connecting to a http/2 capable server, requesting a resource and
+iterating over the response.
 
-In both cases (unidirectional and bidirectional stream), one can send headers and data to the other
-side (via `HeadersStreamMessage` and `DataStreamMessage`).
+```dart
+import 'dart:convert';
+import 'dart:io';
 
-These messages are ordered and will arrive in the same order as they were sent (data messages may be
-split up into multiple smaller chunks or might be combined).
+import 'package:http2/transport.dart';
 
-In the most common case, each direction will send one `HeadersStreamMessage` followed by zero or
-more `DataStreamMessage`s.
+main() async {
+  var uri = Uri.parse('https://www.google.com/');
 
-Establishing a bidirectional stream of bytes to a server is up to the user of this library.
-There are 3 common ways to achive this
+  var transport = new ClientTransportConnection.viaSocket(
+    await SecureSocket.connect(
+      uri.host,
+      uri.port,
+      supportedProtocols: ['h2'],
+    ),
+  );
 
-* connect to a server via SSL and use the ALPN (SSL) protocol extension to negotiate with the server
-  to speak http/2 (the ALPN protocol identifier for http/2 is `h2`).
-* have prior knowledge about the server - i.e. know ahead of time that the server will speak http/2
-  via an unencrypted tcp connection
-* use a http/1.1 connection and upgrade it to http/2
+  var stream = transport.makeRequest(
+    [
+      new Header.ascii(':method', 'GET'),
+      new Header.ascii(':path', uri.path),
+      new Header.ascii(':scheme', uri.scheme),
+      new Header.ascii(':authority', uri.host),
+    ],
+    endStream: true,
+  );
 
-The first way is the most common way and can be done in Dart by using `dart:io`s secure socket
-implementation (by using a `SecurityContext` and including 'h2' in the list of protocols used for
-ALPN).
+  await for (var message in stream.incomingMessages) {
+    if (message is HeadersStreamMessage) {
+      for (var header in message.headers) {
+        var name = utf8.decode(header.name);
+        var value = utf8.decode(header.value);
+        print('Header: $name: $value');
+      }
+    } else if (message is DataStreamMessage) {
+      // Use [message.bytes] (but respect 'content-encoding' header)
+    }
+  }
+  await transport.finish();
+}
+```
 
-For a simple example on how to connect to a http/2 capable server and requesting a resource see:
-https://github.com/dart-lang/http2/blob/master/example/display_headers.dart.
+An example with better error handling is available [here][example].
 
+See the [API docs][api] for more details.
 
 ## Features and bugs
 
@@ -44,3 +59,4 @@ Please file feature requests and bugs at the [issue tracker][tracker].
 
 [tracker]: https://github.com/dart-lang/http2/issues
 [api]: http://www.dartdocs.org/documentation/http2/latest
+[example]: https://github.com/dart-lang/http2/blob/master/example/display_headers.dart.

--- a/lib/transport.dart
+++ b/lib/transport.dart
@@ -39,6 +39,10 @@
 /// The first way is the most common way and can be done in Dart by using
 /// `dart:io`s secure socket implementation (by using a `SecurityContext` and
 /// including 'h2' in the list of protocols used for ALPN).
+///
+///
+/// For a simple example on how to connect to a http/2 capable server and
+/// requesting a resource see: https://github.com/dart-lang/http2/blob/master/example/display_headers.dart.
 library http2.transport;
 
 import 'dart:async';

--- a/lib/transport.dart
+++ b/lib/transport.dart
@@ -28,7 +28,7 @@
 /// of this library. There are 3 common ways to achive this
 ///
 ///     * connect to a server via SSL and use the ALPN (SSL) protocol extension
-///       to negogiate with the server to speak http/2 (the ALPN protocol
+///       to negotiate with the server to speak http/2 (the ALPN protocol
 ///       identifier for http/2 is `h2`)
 ///
 ///     * have prior knowledge about the server - i.e. know ahead of time that
@@ -39,63 +39,6 @@
 /// The first way is the most common way and can be done in Dart by using
 /// `dart:io`s secure socket implementation (by using a `SecurityContext` and
 /// including 'h2' in the list of protocols used for ALPN).
-///
-/// Here is a simple example on how to connect to a http/2 capable server and
-/// requesting a resource:
-///
-///     import 'dart:async';
-///     import 'dart:convert';
-///     import 'dart:io';
-///
-///     import 'package:http2/transport.dart';
-///
-///     main() async {
-///       var uri = Uri.parse("https://www.google.com/");
-///
-///       var socket = await connect(uri);
-///
-///       // The default client settings will disable server pushes. We
-///       // therefore do not need to deal with [stream.peerPushes].
-///       var transport = new ClientTransportConnection.viaSocket(socket);
-///
-///       var headers = [
-///         new Header.ascii(':method', 'GET'),
-///         new Header.ascii(':path', uri.path),
-///         new Header.ascii(':scheme', uri.scheme),
-///         new Header.ascii(':authority', uri.host),
-///       ];
-///
-///       var stream = transport.makeRequest(headers, endStream: true);
-///       await for (var message in stream.incomingMessages) {
-///         if (message is HeadersStreamMessage) {
-///           for (var header in message.headers) {
-///             var name = UTF8.decode(header.name);
-///             var value = UTF8.decode(header.value);
-///             print('$name: $value');
-///           }
-///         } else if (message is DataStreamMessage) {
-///           // Use [message.bytes] (but respect 'content-encoding' header)
-///         }
-///       }
-///       await transport.finish();
-///     }
-///
-///     Future<Socket> connect(Uri uri) async {
-///       bool useSSL = uri.scheme == 'https';
-///       if (useSSL) {
-///         var secureSocket = await SecureSocket.connect(
-///             uri.host, uri.port, supportedProtocols: ['h2']);
-///         if (secureSocket.selectedProtocol != 'h2') {
-///           throw new Exception(
-///               "Failed to negogiate http/2 via alpn. Maybe server "
-///               "doesn't support http/2.");
-///         }
-///         return secureSocket;
-///       } else {
-///         return await Socket.connect(uri.host, uri.port);
-///       }
-///     }
-///
 library http2.transport;
 
 import 'dart:async';

--- a/lib/transport.dart
+++ b/lib/transport.dart
@@ -40,9 +40,8 @@
 /// `dart:io`s secure socket implementation (by using a `SecurityContext` and
 /// including 'h2' in the list of protocols used for ALPN).
 ///
-///
-/// For a simple example on how to connect to a http/2 capable server and
-/// requesting a resource see: https://github.com/dart-lang/http2/blob/master/example/display_headers.dart.
+/// A simple example on how to connect to a http/2 capable server and
+/// requesting a resource is available at https://github.com/dart-lang/http2/blob/master/example/display_headers.dart.
 library http2.transport;
 
 import 'dart:async';


### PR DESCRIPTION
The example in the dart-doc was already obsolete, so I replaced it with a reference to the code example.

In the README there is now a simplified version of the example.

This fixes: https://github.com/dart-lang/http2/issues/2