### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/test/multiprotocol_server_test.dart
+++ b/test/multiprotocol_server_test.dart
@@ -71,7 +71,7 @@ Future makeHttp11Request(
   var request =
       await client.getUrl(Uri.parse('https://localhost:${server.port}/abc$i'));
   var response = await request.close();
-  var body = await response.transform(utf8.decoder).join('');
+  var body = await response.cast<List<int>>().transform(utf8.decoder).join('');
   expect(body, 'answer$i');
 }
 


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900