### PR TITLE
Enable lint unawaited_futures

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -33,6 +33,7 @@ linter:
     - test_types_in_equals
     - throw_in_finally
     - type_init_formals
+    - unawaited_futures
     - unnecessary_const
     - unnecessary_new
     - unrelated_type_equality_checks

--- a/experimental/server.dart
+++ b/experimental/server.dart
@@ -10,6 +10,7 @@ import 'dart:io';
 
 import 'package:http2/src/testing/debug.dart' hide print;
 import 'package:http2/transport.dart';
+import 'package:pedantic/pedantic.dart';
 
 const bool DEBUGGING = false;
 
@@ -58,11 +59,11 @@ handleClient(SecureSocket socket) {
           if (path == null) throw Exception('no path given');
 
           if (path == '/') {
-            sendHtml(stream);
+            unawaited(sendHtml(stream));
           } else if (['/iframe', '/iframe2'].contains(path)) {
-            sendIFrameHtml(stream, path);
+            unawaited(sendIFrameHtml(stream, path));
           } else {
-            send404(stream, path);
+            unawaited(send404(stream, path));
           }
         }
       } else if (msg is DataStreamMessage) {
@@ -98,9 +99,9 @@ void dumpInfo(String prefix, String msg) {
 }
 
 Future sendHtml(ServerTransportStream stream) async {
-  push(stream, '/iframe', sendIFrameHtml);
-  push(stream, '/iframe2', sendIFrameHtml);
-  push(stream, '/favicon.ico', send404);
+  unawaited(push(stream, '/iframe', sendIFrameHtml));
+  unawaited(push(stream, '/iframe2', sendIFrameHtml));
+  unawaited(push(stream, '/favicon.ico', send404));
 
   stream.sendHeaders([
     Header.ascii(':status', '200'),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,3 +10,4 @@ environment:
 dev_dependencies:
   mockito: ^4.0.0
   test: ^1.2.0
+  pedantic: ^1.0.0

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -658,7 +658,8 @@ main() {
               client.makeRequest([Header.ascii('a', 'b')], endStream: false);
 
           // Make sure we don't get messages/pushes on the terminated stream.
-          unawaited(stream.incomingMessages.toList().catchError(expectAsync1((e) {
+          unawaited(
+              stream.incomingMessages.toList().catchError(expectAsync1((e) {
             expect(
                 '$e',
                 contains('This stream was not processed and can '

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 import 'dart:convert' show ascii;
 import 'dart:typed_data';
 
+import 'package:pedantic/pedantic.dart';
 import 'package:test/test.dart';
 
 import 'package:http2/src/connection_preface.dart';
@@ -657,12 +658,12 @@ main() {
               client.makeRequest([Header.ascii('a', 'b')], endStream: false);
 
           // Make sure we don't get messages/pushes on the terminated stream.
-          stream.incomingMessages.toList().catchError(expectAsync1((e) {
+          unawaited(stream.incomingMessages.toList().catchError(expectAsync1((e) {
             expect(
                 '$e',
                 contains('This stream was not processed and can '
                     'therefore be retried'));
-          }));
+          })));
           expect(await stream.peerPushes.toList(), isEmpty);
 
           // Try to gracefully finish the connection.

--- a/test/client_websites_test.dart
+++ b/test/client_websites_test.dart
@@ -9,6 +9,7 @@ import 'dart:convert' show Utf8Decoder, utf8;
 import 'dart:io';
 
 import 'package:http2/src/testing/client.dart';
+import 'package:pedantic/pedantic.dart';
 import 'package:test/test.dart';
 
 main() async {
@@ -20,7 +21,7 @@ main() async {
 
     final utf8Decoder = Utf8Decoder(allowMalformed: true);
     String body = await response.stream.transform(utf8Decoder).join('');
-    connection.close();
+    unawaited(connection.close());
 
     body = body.toLowerCase();
     expect(body, contains('<html'));
@@ -34,7 +35,7 @@ main() async {
     dumpHeaders(uri, response.headers);
 
     String body = await readBody(response);
-    connection.close();
+    unawaited(connection.close());
 
     expect(body, contains('<!DOCTYPE html>'));
     expect(body, contains('twitter.com'));

--- a/test/src/connection_preface_test.dart
+++ b/test/src/connection_preface_test.dart
@@ -7,8 +7,9 @@ library http2.test.connection_preface_test;
 import 'dart:async';
 import 'dart:math' show min;
 
-import 'package:test/test.dart';
 import 'package:http2/src/connection_preface.dart';
+import 'package:pedantic/pedantic.dart';
+import 'package:test/test.dart';
 
 main() {
   group('connection-preface', () {
@@ -27,7 +28,7 @@ main() {
 
           c.add(data.sublist(from, to));
         }
-        c.close();
+        unawaited(c.close());
 
         expect(await resultF, frameBytes);
       }
@@ -41,11 +42,11 @@ main() {
       for (int i = 0; i < CONNECTION_PREFACE.length - 1; i++) {
         c.add([CONNECTION_PREFACE[i]]);
       }
-      c.close();
+      unawaited(c.close());
 
-      resultF.catchError(expectAsync2((error, _) {
+      unawaited(resultF.catchError(expectAsync2((error, _) {
         expect(error, contains('EOS before connection preface could be read'));
-      }));
+      })));
     });
 
     test('wrong-connection-sequence', () async {
@@ -56,11 +57,11 @@ main() {
       for (int i = 0; i < CONNECTION_PREFACE.length; i++) {
         c.add([0xff]);
       }
-      c.close();
+      unawaited(c.close());
 
-      resultF.catchError(expectAsync2((error, _) {
+      unawaited(resultF.catchError(expectAsync2((error, _) {
         expect(error, contains('Connection preface does not match.'));
-      }));
+      })));
     });
 
     test('incoming-socket-error', () async {
@@ -69,11 +70,11 @@ main() {
           readConnectionPreface(c.stream).fold([], (b, d) => b..addAll(d));
 
       c.addError('hello world');
-      c.close();
+      unawaited(c.close());
 
-      resultF.catchError(expectAsync2((error, _) {
+      unawaited(resultF.catchError(expectAsync2((error, _) {
         expect(error, contains('hello world'));
-      }));
+      })));
     });
   });
 }

--- a/test/src/ping/ping_handler_test.dart
+++ b/test/src/ping/ping_handler_test.dart
@@ -9,6 +9,7 @@ import 'package:test/test.dart';
 
 import 'package:http2/src/frames/frames.dart';
 import 'package:http2/src/ping/ping_handler.dart';
+import 'package:pedantic/pedantic.dart';
 
 import '../error_matchers.dart';
 
@@ -65,9 +66,9 @@ main() {
 
       // Ensure outstanding pings will be completed with an error once we call
       // `pingHandler.terminate()`.
-      future.catchError(expectAsync2((error, _) {
+      unawaited(future.catchError(expectAsync2((error, _) {
         expect(error, 'hello world');
-      }));
+      })));
       pingHandler.terminate('hello world');
       verifyNoMoreInteractions(writer);
     });

--- a/test/src/streams/simple_push_test.dart
+++ b/test/src/streams/simple_push_test.dart
@@ -7,8 +7,9 @@ library http2.test.streams.simple_push_test;
 import 'dart:async';
 import 'dart:convert' show utf8;
 
-import 'package:test/test.dart';
 import 'package:http2/transport.dart';
+import 'package:pedantic/pedantic.dart';
+import 'package:test/test.dart';
 
 import 'helper.dart';
 
@@ -65,7 +66,7 @@ main() {
           pushStream.sendHeaders(expectedHeaders);
           await sendData(pushStream, 'pushing "hello world" :)');
 
-          sStream.incomingMessages.drain();
+          unawaited(sStream.incomingMessages.drain());
           sStream.sendHeaders(expectedHeaders, endStream: true);
 
           expect(await serverReceivedAllBytes.future, completes);

--- a/test/src/streams/streams_test.dart
+++ b/test/src/streams/streams_test.dart
@@ -4,8 +4,9 @@
 
 library http2.test.end2end_test;
 
-import 'package:test/test.dart';
 import 'package:http2/transport.dart';
+import 'package:pedantic/pedantic.dart';
+import 'package:test/test.dart';
 
 import 'helper.dart';
 
@@ -85,12 +86,12 @@ main() {
             }, count: 1 + chunks.length), onDone: expectAsync0(() {
           expect(receivedChunks, chunks);
         }));
-        sStream.outgoingMessages.close();
+        unawaited(sStream.outgoingMessages.close());
       }));
 
       TransportStream cStream = client.makeRequest(expectedHeaders);
       chunks.forEach(cStream.sendData);
-      cStream.outgoingMessages.close();
+      unawaited(cStream.outgoingMessages.close());
       expectEmptyStream(cStream.incomingMessages);
     });
 
@@ -172,7 +173,7 @@ main() {
       }));
 
       TransportStream cStream = client.makeRequest(expectedHeaders);
-      cStream.outgoingMessages.close();
+      unawaited(cStream.outgoingMessages.close());
 
       int i = 0;
       cStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {

--- a/test/transport_test.dart
+++ b/test/transport_test.dart
@@ -5,9 +5,10 @@
 import 'dart:async';
 import 'dart:typed_data';
 
-import 'package:test/test.dart';
-import 'package:http2/transport.dart';
 import 'package:http2/src/flowcontrol/window.dart';
+import 'package:http2/transport.dart';
+import 'package:pedantic/pedantic.dart';
+import 'package:test/test.dart';
 
 import 'src/hpack/hpack_test.dart' show isHeader;
 
@@ -29,12 +30,12 @@ main() {
 
       // NOTE: Now the connection is dead and client/server should complete
       // with [TransportException]s when doing work (e.g. ping).
-      client.ping().catchError(expectAsync2((e, s) {
+      unawaited(client.ping().catchError(expectAsync2((e, s) {
         expect(e is TransportException, isTrue);
-      }));
-      server.ping().catchError(expectAsync2((e, s) {
+      })));
+      unawaited(server.ping().catchError(expectAsync2((e, s) {
         expect(e is TransportException, isTrue);
-      }));
+      })));
     });
 
     transportTest('terminated-server-ping',
@@ -47,12 +48,12 @@ main() {
 
       // NOTE: Now the connection is dead and the client/server should complete
       // with [TransportException]s when doing work (e.g. ping).
-      client.ping().catchError(expectAsync2((e, s) {
+      unawaited(client.ping().catchError(expectAsync2((e, s) {
         expect(e is TransportException, isTrue);
-      }));
-      server.ping().catchError(expectAsync2((e, s) {
+      })));
+      unawaited(server.ping().catchError(expectAsync2((e, s) {
         expect(e is TransportException, isTrue);
-      }));
+      })));
     });
 
     const int concurrentStreamLimit = 5;
@@ -345,9 +346,9 @@ main() {
         }, count: 6);
         await for (final stream in server.incomingStreams) {
           stream.sendHeaders([]);
-          stream.incomingMessages
+          unawaited(stream.incomingMessages
               .toList()
-              .then((_) => stream.outgoingMessages.close());
+              .then((_) => stream.outgoingMessages.close()));
         }
         await server.finish();
         expect(activeCount, 3);


### PR DESCRIPTION
This lint typically highlights async bugs. In this case the violations
were all in tests so it is relatively safe to ignore them all (with
`unawaited`) for now as the least disruptive change.

- Add a dev dependency on `pedantic`.
- Use `unawaited` to mask all lints in tests.