### PR TITLE
Remove unnecessary library statements

### DIFF
--- a/experimental/server.dart
+++ b/experimental/server.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.experimental.server;
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/lib/multiprotocol_server.dart
+++ b/lib/multiprotocol_server.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.multiprotocol_server;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/lib/src/artificial_server_socket.dart
+++ b/lib/src/artificial_server_socket.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.artificial_server_socket;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/lib/src/async_utils/async_utils.dart
+++ b/lib/src/async_utils/async_utils.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.src.async_utils.async_utils;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/lib/src/byte_utils.dart
+++ b/lib/src/byte_utils.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.src.byte_utils;
-
 import 'dart:typed_data';
 
 List<int> viewOrSublist(List<int> data, int offset, int length) {

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.src.conn;
-
 import 'dart:async';
 import 'dart:convert' show utf8;
 

--- a/lib/src/connection_preface.dart
+++ b/lib/src/connection_preface.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.src.connection_preface;
-
 import 'dart:async';
 import 'dart:math';
 

--- a/lib/src/error_handler.dart
+++ b/lib/src/error_handler.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.src.error_handler;
-
 import 'dart:async';
 
 import 'sync_errors.dart';

--- a/lib/src/flowcontrol/connection_queues.dart
+++ b/lib/src/flowcontrol/connection_queues.dart
@@ -5,7 +5,6 @@
 // TODO: Take priorities into account.
 // TODO: Properly fragment large data frames, so they are not taking up too much
 // bandwidth.
-library http2.src.flowcontrol.connection_flow_controller;
 
 import 'dart:async';
 import 'dart:collection';

--- a/lib/src/flowcontrol/queue_messages.dart
+++ b/lib/src/flowcontrol/queue_messages.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.src.flowcontrol.queue_messages;
-
 import '../../transport.dart';
 
 /// The subclasses of [Message] are objects that are coming from the

--- a/lib/src/flowcontrol/stream_queues.dart
+++ b/lib/src/flowcontrol/stream_queues.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.src.flowcontrol.stream_queues;
-
 import 'dart:async';
 import 'dart:collection';
 

--- a/lib/src/flowcontrol/window.dart
+++ b/lib/src/flowcontrol/window.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.src.window;
-
 class Window {
   static const int MAX_WINDOW_SIZE = (1 << 31) - 1;
 

--- a/lib/src/flowcontrol/window_handler.dart
+++ b/lib/src/flowcontrol/window_handler.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.src.window_handler;
-
 import '../async_utils/async_utils.dart';
 import '../frames/frames.dart';
 import '../sync_errors.dart';

--- a/lib/src/frames/frame_defragmenter.dart
+++ b/lib/src/frames/frame_defragmenter.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.src.frames.frame_defragmenter;
-
 import '../sync_errors.dart';
 
 import 'frames.dart';

--- a/lib/src/hpack/huffman.dart
+++ b/lib/src/hpack/huffman.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.src.hpack.huffman;
-
 import 'dart:io';
 
 import 'huffman_table.dart';

--- a/lib/src/hpack/huffman_table.dart
+++ b/lib/src/hpack/huffman_table.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.hpack.huffman_table;
-
 import 'huffman.dart';
 
 /// The huffman codec for encoding/decoding HTTP/2 header blocks.

--- a/lib/src/ping/ping_handler.dart
+++ b/lib/src/ping/ping_handler.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.src.ping.ping_handler;
-
 import 'dart:async';
 
 import '../error_handler.dart';

--- a/lib/src/settings/settings.dart
+++ b/lib/src/settings/settings.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.src.settings;
-
 import 'dart:async';
 
 import '../error_handler.dart';

--- a/lib/src/streams/stream_handler.dart
+++ b/lib/src/streams/stream_handler.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.src.stream_handler;
-
 import 'dart:async';
 import 'dart:math';
 

--- a/lib/src/sync_errors.dart
+++ b/lib/src/sync_errors.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.src.sync_errors;
-
 class ProtocolException implements Exception {
   final String _message;
 

--- a/lib/src/testing/client.dart
+++ b/lib/src/testing/client.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.client;
-
 import 'dart:async';
 import 'dart:convert' show ascii;
 import 'dart:io';

--- a/lib/src/testing/debug.dart
+++ b/lib/src/testing/debug.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.debug;
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.test.client_tests;
-
 import 'dart:async';
 import 'dart:convert' show ascii;
 import 'dart:typed_data';

--- a/test/client_websites_test.dart
+++ b/test/client_websites_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.test.client_websites_test;
-
 import 'dart:async';
 import 'dart:convert' show Utf8Decoder, utf8;
 import 'dart:io';

--- a/test/multiprotocol_server_test.dart
+++ b/test/multiprotocol_server_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.test.client_tests;
-
 import 'dart:async';
 import 'dart:convert' show ascii, utf8;
 import 'dart:io';

--- a/test/server_test.dart
+++ b/test/server_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.test.server_tests;
-
 import 'dart:async';
 
 import 'package:test/test.dart';

--- a/test/src/connection_preface_test.dart
+++ b/test/src/connection_preface_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.test.connection_preface_test;
-
 import 'dart:async';
 import 'dart:math' show min;
 

--- a/test/src/error_matchers.dart
+++ b/test/src/error_matchers.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.test.error_matchers;
-
 import 'package:test/test.dart';
 import 'package:http2/src/sync_errors.dart';
 

--- a/test/src/streams/helper.dart
+++ b/test/src/streams/helper.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.test.end2end_test;
-
 import 'dart:async';
 
 import 'package:test/test.dart';

--- a/test/src/streams/simple_flow_test.dart
+++ b/test/src/streams/simple_flow_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.test.streams.simple_flow_test;
-
 import 'dart:async';
 
 import 'package:test/test.dart';

--- a/test/src/streams/simple_push_test.dart
+++ b/test/src/streams/simple_push_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.test.streams.simple_push_test;
-
 import 'dart:async';
 import 'dart:convert' show utf8;
 

--- a/test/src/streams/streams_test.dart
+++ b/test/src/streams/streams_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library http2.test.end2end_test;
-
 import 'package:test/test.dart';
 import 'package:http2/transport.dart';
 


### PR DESCRIPTION
These statements are no longer useful unless there is a library level
doc comment or part files referencing the library name. Modern Dart
style does not use them.