### PR TITLE
Enable package:pedantic lints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-  - 2.0.0
+  - 2.5.0
   - dev
 
 dart_task:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,4 @@
+include: package:pedantic/analysis_options.yaml
 analyzer:
   errors:
     unused_element: error
@@ -6,39 +7,15 @@ analyzer:
     dead_code: error
 linter:
   rules:
-    - always_declare_return_types
-    - annotate_overrides
-    - avoid_empty_else
-    - avoid_init_to_null
-    - avoid_return_types_on_setters
     - await_only_futures
     - camel_case_types
     - comment_references
     - control_flow_in_finally
     - directives_ordering
-    - empty_catches
-    - empty_constructor_bodies
     - empty_statements
     - hash_and_equals
     - implementation_imports
-    - library_names
-    - library_prefixes
     - non_constant_identifier_names
-    - omit_local_variable_types
     - only_throw_errors
-    - prefer_equal_for_default_values
-    - prefer_final_fields
-    - prefer_generic_function_type_aliases
-    - prefer_is_empty
-    - prefer_is_not_empty
-    - prefer_single_quotes
-    - slash_for_doc_comments
     - test_types_in_equals
     - throw_in_finally
-    - type_init_formals
-    - unawaited_futures
-    - unnecessary_const
-    - unnecessary_new
-    - unrelated_type_equality_checks
-    - use_function_type_syntax_for_parameters
-    - valid_regexps

--- a/lib/multiprotocol_server.dart
+++ b/lib/multiprotocol_server.dart
@@ -25,7 +25,7 @@ class MultiProtocolHttpServer {
 
   StreamController<http2.ServerTransportStream> _http2Controller;
   Stream<http2.ServerTransportStream> _http2Server;
-  final _http2Connections = Set<http2.ServerTransportConnection>();
+  final _http2Connections = <http2.ServerTransportConnection>{};
 
   MultiProtocolHttpServer._(this._serverSocket, this._settings) {
     _http11Controller =

--- a/lib/src/flowcontrol/connection_queues.dart
+++ b/lib/src/flowcontrol/connection_queues.dart
@@ -334,7 +334,7 @@ class ConnectionMessageQueueIn extends Object
   }
 
   void forceDispatchIncomingMessages() {
-    final toBeRemoved = Set<int>();
+    final toBeRemoved = <int>{};
     _stream2pendingMessages.forEach((int streamId, Queue<Message> messages) {
       final mq = _stream2messageQueue[streamId];
       while (messages.isNotEmpty) {

--- a/lib/src/frames/frame_reader.dart
+++ b/lib/src/frames/frame_reader.dart
@@ -19,7 +19,7 @@ class FrameReader {
 
   /// Starts to listen on the input stream and decodes HTTP/2 transport frames.
   Stream<Frame> startDecoding() {
-    var bufferedData = List<List<int>>();
+    var bufferedData = <List<int>>[];
     var bufferedLength = 0;
 
     FrameHeader tryReadHeader() {
@@ -74,9 +74,7 @@ class FrameReader {
 
             try {
               while (true) {
-                if (header == null) {
-                  header = tryReadHeader();
-                }
+                header ??= tryReadHeader();
                 if (header != null) {
                   if (header.length > _localSettings.maxFrameSize) {
                     terminateWithError(

--- a/lib/src/hpack/huffman.dart
+++ b/lib/src/hpack/huffman.dart
@@ -70,7 +70,9 @@ class HuffmanDecoder {
             'Incomplete encoding of a byte or more than 7 bit padding.');
       }
 
-      while (node.right != null) node = node.right;
+      while (node.right != null) {
+        node = node.right;
+      }
 
       if (node.value != 256) {
         throw HuffmanDecodingException('Incomplete encoding of a byte.');
@@ -163,14 +165,10 @@ HuffmanTreeNode generateHuffmanTree(List<EncodedHuffmanValue> valueEncodings) {
           ((entry.encodedBytes >> (entry.numBits - bitNr - 1)) & 1) == 1;
 
       if (right) {
-        if (current.right == null) {
-          current.right = HuffmanTreeNode();
-        }
+        current.right ??= HuffmanTreeNode();
         current = current.right;
       } else {
-        if (current.left == null) {
-          current.left = HuffmanTreeNode();
-        }
+        current.left ??= HuffmanTreeNode();
         current = current.left;
       }
     }

--- a/lib/src/streams/stream_handler.dart
+++ b/lib/src/streams/stream_handler.dart
@@ -322,15 +322,8 @@ class StreamHandler extends Object with TerminatableMixin, ClosableMixin {
     incomingQueue.insertNewStreamMessageQueue(streamId, streamQueueIn);
 
     var _outgoingC = StreamController<StreamMessage>();
-    var stream = Http2StreamImpl(
-        streamQueueIn,
-        streamQueueOut,
-        _outgoingC,
-        streamId,
-        windowOutHandler,
-        this._canPush,
-        this._push,
-        this._terminateStream);
+    var stream = Http2StreamImpl(streamQueueIn, streamQueueOut, _outgoingC,
+        streamId, windowOutHandler, _canPush, _push, _terminateStream);
     final wasIdle = _openStreams.isEmpty;
     _openStreams[stream.id] = stream;
 
@@ -366,7 +359,7 @@ class StreamHandler extends Object with TerminatableMixin, ClosableMixin {
   bool _canPush(Http2StreamImpl stream) {
     var openState = (stream.state == StreamState.Open ||
         stream.state == StreamState.HalfClosedRemote);
-    var pushEnabled = this._peerSettings.enablePush;
+    var pushEnabled = _peerSettings.enablePush;
     return openState &&
         pushEnabled &&
         _canCreateNewStream() &&

--- a/lib/transport.dart
+++ b/lib/transport.dart
@@ -77,7 +77,7 @@ abstract class ClientTransportConnection extends TransportConnection {
   factory ClientTransportConnection.viaStreams(
       Stream<List<int>> incoming, StreamSink<List<int>> outgoing,
       {ClientSettings settings}) {
-    if (settings == null) settings = const ClientSettings();
+    settings ??= const ClientSettings();
     return ClientConnection(incoming, outgoing, settings);
   }
 
@@ -101,7 +101,7 @@ abstract class ServerTransportConnection extends TransportConnection {
       Stream<List<int>> incoming, StreamSink<List<int>> outgoing,
       {ServerSettings settings =
           const ServerSettings(concurrentStreamLimit: 1000)}) {
-    if (settings == null) settings = const ServerSettings();
+    settings ??= const ServerSettings();
     return ServerConnection(incoming, outgoing, settings);
   }
 
@@ -174,7 +174,7 @@ abstract class ServerTransportStream extends TransportStream {
 abstract class StreamMessage {
   final bool endStream;
 
-  StreamMessage({bool endStream}) : this.endStream = endStream ?? false;
+  StreamMessage({bool endStream}) : endStream = endStream ?? false;
 }
 
 /// Represents a data message which can be sent over a HTTP/2 stream.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/http2
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.5.0 <3.0.0'
 
 dev_dependencies:
   mockito: ^4.0.0

--- a/test/src/frames/frame_writer_reader_test.dart
+++ b/test/src/frames/frame_writer_reader_test.dart
@@ -201,9 +201,10 @@ void main() {
         expect(contFrame.header.streamId, 99);
         expect(contFrame.hasEndHeadersFlag, isTrue);
 
-        var headerBlock = <int>[]
-          ..addAll(headersFrame.headerBlockFragment)
-          ..addAll(contFrame.headerBlockFragment);
+        var headerBlock = <int>[
+          ...headersFrame.headerBlockFragment,
+          ...contFrame.headerBlockFragment
+        ];
 
         var headers = decoder.decode(headerBlock);
         expect(headers.length, 1);


### PR DESCRIPTION
Fix the remaining new lints:
- curly_braces_in_flow_control_structures
- prefer_collection_literals
- prefer_conditional_assignment
- prefer_spread_collections
- unnecessary_this

Remove the manually specified lints that overlap with pedantic.

Bump to a more recent SDK to support enhanced collection literals.