### PR TITLE
Use hasLength in tests

### DIFF
--- a/test/src/flowcontrol/stream_queues_test.dart
+++ b/test/src/flowcontrol/stream_queues_test.dart
@@ -62,7 +62,7 @@ void main() {
         verify(windowMock.decreaseWindow(1)).called(BYTES.length);
         final messages =
             verify(connectionQueueMock.enqueueMessage(captureAny)).captured;
-        expect(messages.length, BYTES.length);
+        expect(messages, hasLength(BYTES.length));
         for (var counter = 0; counter < messages.length; counter++) {
           expect(messages[counter], const TypeMatcher<DataMessage>());
           DataMessage dataMessage = messages[counter];

--- a/test/src/frames/frame_reader_test.dart
+++ b/test/src/frames/frame_reader_test.dart
@@ -38,7 +38,7 @@ void main() {
         var body = List.filled(maxFrameSize, 0x42);
         dataFrame(body).listen(expectAsync1((Frame frame) {
           expect(frame is DataFrame, isTrue);
-          expect(frame.header.length, body.length);
+          expect(frame.header, hasLength(body.length));
           expect(frame.header.flags, 0);
           DataFrame dataFrame = frame;
           expect(dataFrame.hasEndStreamFlag, isFalse);

--- a/test/src/frames/frame_writer_reader_test.dart
+++ b/test/src/frames/frame_writer_reader_test.dart
@@ -20,7 +20,7 @@ void main() {
         writer.writeDataFrame(99, [1, 2, 3], endStream: true);
 
         var frames = await finishWriting(writer, reader);
-        expect(frames.length, 1);
+        expect(frames, hasLength(1));
         expect(frames[0] is DataFrame, isTrue);
 
         DataFrame dataFrame = frames[0];
@@ -36,7 +36,7 @@ void main() {
         writer.writeHeadersFrame(99, [Header.ascii('a', 'b')], endStream: true);
 
         var frames = await finishWriting(writer, reader);
-        expect(frames.length, 1);
+        expect(frames, hasLength(1));
         expect(frames[0] is HeadersFrame, isTrue);
 
         HeadersFrame headersFrame = frames[0];
@@ -51,7 +51,7 @@ void main() {
         expect(headersFrame.weight, isNull);
 
         var headers = decoder.decode(headersFrame.headerBlockFragment);
-        expect(headers.length, 1);
+        expect(headers, hasLength(1));
         expect(headers[0], isHeader('a', 'b'));
       });
 
@@ -60,7 +60,7 @@ void main() {
         writer.writePriorityFrame(99, 44, 33, exclusive: true);
 
         var frames = await finishWriting(writer, reader);
-        expect(frames.length, 1);
+        expect(frames, hasLength(1));
         expect(frames[0] is PriorityFrame, isTrue);
 
         PriorityFrame priorityFrame = frames[0];
@@ -75,7 +75,7 @@ void main() {
         writer.writeRstStreamFrame(99, 42);
 
         var frames = await finishWriting(writer, reader);
-        expect(frames.length, 1);
+        expect(frames, hasLength(1));
         expect(frames[0] is RstStreamFrame, isTrue);
 
         RstStreamFrame rstFrame = frames[0];
@@ -88,13 +88,13 @@ void main() {
         writer.writeSettingsFrame([Setting(Setting.SETTINGS_ENABLE_PUSH, 1)]);
 
         var frames = await finishWriting(writer, reader);
-        expect(frames.length, 1);
+        expect(frames, hasLength(1));
         expect(frames[0] is SettingsFrame, isTrue);
 
         SettingsFrame settingsFrame = frames[0];
         expect(settingsFrame.hasAckFlag, false);
         expect(settingsFrame.header.streamId, 0);
-        expect(settingsFrame.settings.length, 1);
+        expect(settingsFrame.settings, hasLength(1));
         expect(
             settingsFrame.settings[0].identifier, Setting.SETTINGS_ENABLE_PUSH);
         expect(settingsFrame.settings[0].value, 1);
@@ -105,13 +105,13 @@ void main() {
         writer.writeSettingsAckFrame();
 
         var frames = await finishWriting(writer, reader);
-        expect(frames.length, 1);
+        expect(frames, hasLength(1));
         expect(frames[0] is SettingsFrame, isTrue);
 
         SettingsFrame settingsFrame = frames[0];
         expect(settingsFrame.hasAckFlag, true);
         expect(settingsFrame.header.streamId, 0);
-        expect(settingsFrame.settings.length, 0);
+        expect(settingsFrame.settings, hasLength(0));
       });
 
       writerReaderTest('push-promise-frame',
@@ -119,7 +119,7 @@ void main() {
         writer.writePushPromiseFrame(99, 44, [Header.ascii('a', 'b')]);
 
         var frames = await finishWriting(writer, reader);
-        expect(frames.length, 1);
+        expect(frames, hasLength(1));
         expect(frames[0] is PushPromiseFrame, isTrue);
 
         PushPromiseFrame pushPromiseFrame = frames[0];
@@ -130,7 +130,7 @@ void main() {
         expect(pushPromiseFrame.promisedStreamId, 44);
 
         var headers = decoder.decode(pushPromiseFrame.headerBlockFragment);
-        expect(headers.length, 1);
+        expect(headers, hasLength(1));
         expect(headers[0], isHeader('a', 'b'));
       });
 
@@ -139,7 +139,7 @@ void main() {
         writer.writePingFrame(44, ack: true);
 
         var frames = await finishWriting(writer, reader);
-        expect(frames.length, 1);
+        expect(frames, hasLength(1));
         expect(frames[0] is PingFrame, isTrue);
 
         PingFrame pingFrame = frames[0];
@@ -153,7 +153,7 @@ void main() {
         writer.writeGoawayFrame(44, 33, [1, 2, 3]);
 
         var frames = await finishWriting(writer, reader);
-        expect(frames.length, 1);
+        expect(frames, hasLength(1));
         expect(frames[0] is GoawayFrame, isTrue);
 
         GoawayFrame goawayFrame = frames[0];
@@ -168,7 +168,7 @@ void main() {
         writer.writeWindowUpdate(55, streamId: 99);
 
         var frames = await finishWriting(writer, reader);
-        expect(frames.length, 1);
+        expect(frames, hasLength(1));
         expect(frames[0] is WindowUpdateFrame, isTrue);
 
         WindowUpdateFrame windowUpdateFrame = frames[0];
@@ -185,7 +185,7 @@ void main() {
         writer.writeHeadersFrame(99, [header], endStream: true);
 
         var frames = await finishWriting(writer, reader);
-        expect(frames.length, 2);
+        expect(frames, hasLength(2));
         expect(frames[0] is HeadersFrame, isTrue);
         expect(frames[1] is ContinuationFrame, isTrue);
 
@@ -207,7 +207,7 @@ void main() {
         ];
 
         var headers = decoder.decode(headerBlock);
-        expect(headers.length, 1);
+        expect(headers, hasLength(1));
         expect(headers[0].name, headerName);
         expect(headers[0].value, headerValue);
       });

--- a/test/src/hpack/hpack_test.dart
+++ b/test/src/hpack/hpack_test.dart
@@ -790,7 +790,7 @@ class TestHelper {
 
   static void expectHeader(Header h, int len, int nameChar, int valueChar) {
     var data = h.value;
-    expect(data.length, len - 32 - 1);
+    expect(data, hasLength(len - 32 - 1));
     for (var i = 0; i < data.length; i++) {
       expect(data[i], valueChar);
     }

--- a/test/src/streams/simple_push_test.dart
+++ b/test/src/streams/simple_push_test.dart
@@ -21,7 +21,7 @@ void main() {
       allBytes.addAll(List.generate(42, (i) => 42));
 
       void testHeaders(List<Header> headers) {
-        expect(headers.length, expectedHeaders.length);
+        expect(headers, hasLength(expectedHeaders.length));
         for (var i = 0; i < headers.length; i++) {
           expect(headers[i].name, expectedHeaders[i].name);
           expect(headers[i].value, expectedHeaders[i].value);


### PR DESCRIPTION
The failure message for specific matchers is nicer than comparing ints.
Find places using `expression.length` as the actual and a number as the
expected, and rewrite with the `hasLength` matcher.