### PR TITLE
Disable implicit casts

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,7 @@
 include: package:pedantic/analysis_options.yaml
 analyzer:
+  strong-mode:
+    implicit-casts: false
   errors:
     unused_element: error
     unused_import: error

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -145,8 +145,8 @@ void main() {
 
           handshakeCompleter.complete();
 
-          HeadersFrame headers = await nextFrame();
-          DataFrame finFrame = await nextFrame();
+          var headers = await nextFrame() as HeadersFrame;
+          var finFrame = await nextFrame() as DataFrame;
           expect(finFrame.hasEndStreamFlag, true);
 
           // Write a data frame for a non-existent stream.
@@ -197,8 +197,8 @@ void main() {
 
           handshakeCompleter.complete();
 
-          HeadersFrame headers = await nextFrame();
-          DataFrame finFrame = await nextFrame();
+          var headers = await nextFrame() as HeadersFrame;
+          var finFrame = await nextFrame() as DataFrame;
           expect(finFrame.hasEndStreamFlag, true);
 
           var streamId = headers.header.streamId;
@@ -264,8 +264,8 @@ void main() {
 
           handshakeCompleter.complete();
 
-          HeadersFrame headers = await nextFrame();
-          DataFrame finFrame = await nextFrame();
+          var headers = await nextFrame() as HeadersFrame;
+          var finFrame = await nextFrame() as DataFrame;
           expect(finFrame.hasEndStreamFlag, true);
 
           var streamId = headers.header.streamId;
@@ -341,7 +341,7 @@ void main() {
 
           handshakeCompleter.complete();
 
-          HeadersFrame headers = await nextFrame();
+          var headers = await nextFrame() as HeadersFrame;
 
           var streamId = headers.header.streamId;
 
@@ -367,7 +367,7 @@ void main() {
           expect(win.windowSizeIncrement, 1);
 
           await clientDone.future;
-          DataFrame finFrame = await nextFrame();
+          var finFrame = await nextFrame() as DataFrame;
           expect(finFrame.hasEndStreamFlag, true);
 
           // Wait for the client finish.
@@ -411,8 +411,8 @@ void main() {
 
           handshakeCompleter.complete();
 
-          HeadersFrame headers = await nextFrame();
-          DataFrame finFrame = await nextFrame();
+          var headers = await nextFrame() as HeadersFrame;
+          var finFrame = await nextFrame() as DataFrame;
           expect(finFrame.hasEndStreamFlag, true);
 
           var streamId = headers.header.streamId;
@@ -427,7 +427,7 @@ void main() {
               streamId, pushStreamId, [Header.ascii('a', 'b')]);
 
           // Make sure we get a connection error.
-          GoawayFrame frame = await nextFrame();
+          var frame = await nextFrame() as GoawayFrame;
           expect(ascii.decode(frame.debugData),
               contains('Cannot push on a non-existent stream'));
           expect(await serverReader.moveNext(), false);
@@ -464,7 +464,7 @@ void main() {
 
           handshakeCompleter.complete();
 
-          HeadersFrame headers = await nextFrame();
+          var headers = await nextFrame() as HeadersFrame;
           var streamId = headers.header.streamId;
 
           // Write response.
@@ -476,7 +476,7 @@ void main() {
               streamId, pushStreamId, [Header.ascii('a', 'b')]);
 
           // Make sure we get a connection error.
-          GoawayFrame frame = await nextFrame();
+          var frame = await nextFrame() as GoawayFrame;
           expect(
               ascii.decode(frame.debugData),
               contains(
@@ -515,7 +515,7 @@ void main() {
 
           handshakeCompleter.complete();
 
-          HeadersFrame headers = await nextFrame();
+          var headers = await nextFrame() as HeadersFrame;
           var streamId = headers.header.streamId;
 
           // Write more than [kFlowControlWindowSize] bytes.
@@ -529,7 +529,7 @@ void main() {
 
           // Read the resulting [GoawayFrame] and assert the error message
           // describes that the flow control window became negative.
-          GoawayFrame frame = await nextFrame();
+          var frame = await nextFrame() as GoawayFrame;
           expect(
               ascii.decode(frame.debugData),
               contains('Connection level flow control window became '

--- a/test/multiprotocol_server_test.dart
+++ b/test/multiprotocol_server_test.dart
@@ -95,7 +95,7 @@ Future makeHttp2Request(MultiProtocolHttpServer server,
 
   expect(await si.moveNext(), true);
   expect(si.current is HeadersStreamMessage, true);
-  var responseHeaders = getHeaders(si.current);
+  var responseHeaders = getHeaders(si.current as HeadersStreamMessage);
   expect(responseHeaders[':status'], '200');
 
   expect(await si.moveNext(), true);
@@ -109,7 +109,7 @@ Future handleHttp2Request(ServerTransportStream stream, int i) async {
 
   expect(await si.moveNext(), true);
   expect(si.current is HeadersStreamMessage, true);
-  var headers = getHeaders(si.current);
+  var headers = getHeaders(si.current as HeadersStreamMessage);
 
   expect(headers[':path'], '/abc$i');
   expect(await si.moveNext(), false);

--- a/test/src/flowcontrol/connection_queues_test.dart
+++ b/test/src/flowcontrol/connection_queues_test.dart
@@ -17,8 +17,8 @@ import 'package:http2/src/flowcontrol/queue_messages.dart';
 void main() {
   group('flowcontrol', () {
     test('connection-message-queue-out', () {
-      dynamic fw = MockFrameWriter();
-      dynamic windowMock = MockOutgoingWindowHandler();
+      var fw = MockFrameWriter();
+      var windowMock = MockOutgoingWindowHandler();
       var queue = ConnectionMessageQueueOut(windowMock, fw);
 
       fw.bufferIndicator.markUnBuffered();
@@ -92,12 +92,12 @@ void main() {
       const STREAM_ID = 99;
       final bytes = [1, 2, 3];
 
-      dynamic windowMock = MockIncomingWindowHandler();
+      var windowMock = MockIncomingWindowHandler();
 
       var queue = ConnectionMessageQueueIn(windowMock, (f) => f());
       expect(queue.pendingMessages, 0);
 
-      dynamic streamQueueMock = MockStreamMessageQueueIn();
+      var streamQueueMock = MockStreamMessageQueueIn();
       queue.insertNewStreamMessageQueue(STREAM_ID, streamQueueMock);
 
       // Insert a [DataFrame] and let it be buffered.
@@ -115,8 +115,9 @@ void main() {
       // specific queue.
       streamQueueMock.bufferIndicator.markUnBuffered();
       verify(windowMock.dataProcessed(bytes.length)).called(1);
-      DataMessage capturedMessage =
-          verify(streamQueueMock.enqueueMessage(captureAny)).captured.single;
+      var capturedMessage = verify(streamQueueMock.enqueueMessage(captureAny))
+          .captured
+          .single as DataMessage;
       expect(capturedMessage.streamId, STREAM_ID);
       expect(capturedMessage.bytes, bytes);
 
@@ -130,7 +131,7 @@ void main() {
       const STREAM_ID = 99;
       final bytes = [1, 2, 3];
 
-      dynamic windowMock = MockIncomingWindowHandler();
+      var windowMock = MockIncomingWindowHandler();
       var queue = ConnectionMessageQueueIn(windowMock, (f) => f());
 
       // Insert a [DataFrame] and let it be buffered.

--- a/test/src/flowcontrol/stream_queues_test.dart
+++ b/test/src/flowcontrol/stream_queues_test.dart
@@ -19,8 +19,8 @@ void main() {
 
     group('stream-message-queue-out', () {
       test('window-big-enough', () {
-        dynamic connectionQueueMock = MockConnectionMessageQueueOut();
-        dynamic windowMock = MockOutgoingStreamWindowHandler();
+        var connectionQueueMock = MockConnectionMessageQueueOut();
+        var windowMock = MockOutgoingStreamWindowHandler();
 
         windowMock.positiveWindow.markUnBuffered();
         var queue =
@@ -37,14 +37,14 @@ void main() {
                 .captured
                 .single;
         expect(capturedMessage, const TypeMatcher<DataMessage>());
-        DataMessage capturedDataMessage = capturedMessage;
+        var capturedDataMessage = capturedMessage as DataMessage;
         expect(capturedDataMessage.bytes, BYTES);
         expect(capturedDataMessage.endStream, isTrue);
       });
 
       test('window-smaller-than-necessary', () {
-        dynamic connectionQueueMock = MockConnectionMessageQueueOut();
-        dynamic windowMock = MockOutgoingStreamWindowHandler();
+        var connectionQueueMock = MockConnectionMessageQueueOut();
+        var windowMock = MockOutgoingStreamWindowHandler();
 
         windowMock.positiveWindow.markUnBuffered();
         var queue =
@@ -65,7 +65,7 @@ void main() {
         expect(messages, hasLength(BYTES.length));
         for (var counter = 0; counter < messages.length; counter++) {
           expect(messages[counter], const TypeMatcher<DataMessage>());
-          DataMessage dataMessage = messages[counter];
+          var dataMessage = messages[counter] as DataMessage;
           expect(dataMessage.bytes, BYTES.sublist(counter, counter + 1));
           expect(dataMessage.endStream, counter == BYTES.length - 1);
         }
@@ -94,14 +94,14 @@ void main() {
 
     group('stream-message-queue-in', () {
       test('data-end-of-stream', () {
-        dynamic windowMock = MockIncomingWindowHandler();
-        dynamic queue = StreamMessageQueueIn(windowMock);
+        var windowMock = MockIncomingWindowHandler();
+        var queue = StreamMessageQueueIn(windowMock);
 
         expect(queue.pendingMessages, 0);
         queue.messages.listen(expectAsync1((StreamMessage message) {
           expect(message is DataStreamMessage, isTrue);
 
-          DataStreamMessage dataMessage = message;
+          var dataMessage = message as DataStreamMessage;
           expect(dataMessage.bytes, BYTES);
         }), onDone: expectAsync0(() {}));
         queue.enqueueMessage(DataMessage(STREAM_ID, BYTES, true));
@@ -118,8 +118,8 @@ void main() {
       const STREAM_ID = 99;
       final bytes = [1, 2, 3];
 
-      dynamic windowMock = MockIncomingWindowHandler();
-      dynamic queue = StreamMessageQueueIn(windowMock);
+      var windowMock = MockIncomingWindowHandler();
+      var queue = StreamMessageQueueIn(windowMock);
 
       var sub = queue.messages.listen(expectAsync1((_) {}, count: 0),
           onDone: expectAsync0(() {}, count: 0));

--- a/test/src/flowcontrol/window_handler_test.dart
+++ b/test/src/flowcontrol/window_handler_test.dart
@@ -102,7 +102,7 @@ void main() {
     test('incoming-window-handler', () {
       const STREAM_ID = 99;
 
-      dynamic fw = FrameWriterMock();
+      var fw = FrameWriterMock();
       var window = Window();
       var initialSize = window.size;
       var handler = IncomingWindowHandler.stream(fw, window, STREAM_ID);

--- a/test/src/frames/frame_defragmenter_test.dart
+++ b/test/src/frames/frame_defragmenter_test.dart
@@ -54,7 +54,7 @@ void main() {
 
         expect(defrag.tryDefragmentFrame(f1), isNull);
         expect(defrag.tryDefragmentFrame(f2), isNull);
-        HeadersFrame h = defrag.tryDefragmentFrame(f3);
+        var h = defrag.tryDefragmentFrame(f3) as HeadersFrame;
         expect(h.hasEndHeadersFlag, isTrue);
         expect(h.hasEndStreamFlag, isFalse);
         expect(h.hasPaddedFlag, isFalse);
@@ -71,7 +71,7 @@ void main() {
 
         expect(defrag.tryDefragmentFrame(f1), isNull);
         expect(defrag.tryDefragmentFrame(f2), isNull);
-        PushPromiseFrame h = defrag.tryDefragmentFrame(f3);
+        var h = defrag.tryDefragmentFrame(f3) as PushPromiseFrame;
         expect(h.hasEndHeadersFlag, isTrue);
         expect(h.hasPaddedFlag, isFalse);
         expect(h.padLength, 0);

--- a/test/src/frames/frame_reader_test.dart
+++ b/test/src/frames/frame_reader_test.dart
@@ -40,7 +40,7 @@ void main() {
           expect(frame is DataFrame, isTrue);
           expect(frame.header, hasLength(body.length));
           expect(frame.header.flags, 0);
-          DataFrame dataFrame = frame;
+          var dataFrame = frame as DataFrame;
           expect(dataFrame.hasEndStreamFlag, isFalse);
           expect(dataFrame.hasPaddedFlag, isFalse);
           expect(dataFrame.bytes, body);

--- a/test/src/frames/frame_writer_reader_test.dart
+++ b/test/src/frames/frame_writer_reader_test.dart
@@ -23,7 +23,7 @@ void main() {
         expect(frames, hasLength(1));
         expect(frames[0] is DataFrame, isTrue);
 
-        DataFrame dataFrame = frames[0];
+        var dataFrame = frames[0] as DataFrame;
         expect(dataFrame.header.streamId, 99);
         expect(dataFrame.hasPaddedFlag, isFalse);
         expect(dataFrame.padLength, 0);
@@ -39,7 +39,7 @@ void main() {
         expect(frames, hasLength(1));
         expect(frames[0] is HeadersFrame, isTrue);
 
-        HeadersFrame headersFrame = frames[0];
+        var headersFrame = frames[0] as HeadersFrame;
         expect(headersFrame.header.streamId, 99);
         expect(headersFrame.hasPaddedFlag, isFalse);
         expect(headersFrame.padLength, 0);
@@ -63,7 +63,7 @@ void main() {
         expect(frames, hasLength(1));
         expect(frames[0] is PriorityFrame, isTrue);
 
-        PriorityFrame priorityFrame = frames[0];
+        var priorityFrame = frames[0] as PriorityFrame;
         expect(priorityFrame.header.streamId, 99);
         expect(priorityFrame.exclusiveDependency, isTrue);
         expect(priorityFrame.streamDependency, 44);
@@ -78,7 +78,7 @@ void main() {
         expect(frames, hasLength(1));
         expect(frames[0] is RstStreamFrame, isTrue);
 
-        RstStreamFrame rstFrame = frames[0];
+        var rstFrame = frames[0] as RstStreamFrame;
         expect(rstFrame.header.streamId, 99);
         expect(rstFrame.errorCode, 42);
       });
@@ -91,7 +91,7 @@ void main() {
         expect(frames, hasLength(1));
         expect(frames[0] is SettingsFrame, isTrue);
 
-        SettingsFrame settingsFrame = frames[0];
+        var settingsFrame = frames[0] as SettingsFrame;
         expect(settingsFrame.hasAckFlag, false);
         expect(settingsFrame.header.streamId, 0);
         expect(settingsFrame.settings, hasLength(1));
@@ -108,7 +108,7 @@ void main() {
         expect(frames, hasLength(1));
         expect(frames[0] is SettingsFrame, isTrue);
 
-        SettingsFrame settingsFrame = frames[0];
+        var settingsFrame = frames[0] as SettingsFrame;
         expect(settingsFrame.hasAckFlag, true);
         expect(settingsFrame.header.streamId, 0);
         expect(settingsFrame.settings, hasLength(0));
@@ -122,7 +122,7 @@ void main() {
         expect(frames, hasLength(1));
         expect(frames[0] is PushPromiseFrame, isTrue);
 
-        PushPromiseFrame pushPromiseFrame = frames[0];
+        var pushPromiseFrame = frames[0] as PushPromiseFrame;
         expect(pushPromiseFrame.header.streamId, 99);
         expect(pushPromiseFrame.hasEndHeadersFlag, isTrue);
         expect(pushPromiseFrame.hasPaddedFlag, isFalse);
@@ -142,7 +142,7 @@ void main() {
         expect(frames, hasLength(1));
         expect(frames[0] is PingFrame, isTrue);
 
-        PingFrame pingFrame = frames[0];
+        var pingFrame = frames[0] as PingFrame;
         expect(pingFrame.header.streamId, 0);
         expect(pingFrame.opaqueData, 44);
         expect(pingFrame.hasAckFlag, isTrue);
@@ -156,7 +156,7 @@ void main() {
         expect(frames, hasLength(1));
         expect(frames[0] is GoawayFrame, isTrue);
 
-        GoawayFrame goawayFrame = frames[0];
+        var goawayFrame = frames[0] as GoawayFrame;
         expect(goawayFrame.header.streamId, 0);
         expect(goawayFrame.lastStreamId, 44);
         expect(goawayFrame.errorCode, 33);
@@ -171,7 +171,7 @@ void main() {
         expect(frames, hasLength(1));
         expect(frames[0] is WindowUpdateFrame, isTrue);
 
-        WindowUpdateFrame windowUpdateFrame = frames[0];
+        var windowUpdateFrame = frames[0] as WindowUpdateFrame;
         expect(windowUpdateFrame.header.streamId, 99);
         expect(windowUpdateFrame.windowSizeIncrement, 55);
       });
@@ -189,7 +189,7 @@ void main() {
         expect(frames[0] is HeadersFrame, isTrue);
         expect(frames[1] is ContinuationFrame, isTrue);
 
-        HeadersFrame headersFrame = frames[0];
+        var headersFrame = frames[0] as HeadersFrame;
         expect(headersFrame.header.streamId, 99);
         expect(headersFrame.hasPaddedFlag, isFalse);
         expect(headersFrame.padLength, 0);
@@ -197,7 +197,7 @@ void main() {
         expect(headersFrame.hasEndStreamFlag, isTrue);
         expect(headersFrame.hasPriorityFlag, isFalse);
 
-        ContinuationFrame contFrame = frames[1];
+        var contFrame = frames[1] as ContinuationFrame;
         expect(contFrame.header.streamId, 99);
         expect(contFrame.hasEndHeadersFlag, isTrue);
 
@@ -229,5 +229,5 @@ void writerReaderTest(String name,
 
 Future<List<Frame>> finishWriting(FrameWriter writer, FrameReader reader) {
   return Future.wait([writer.close(), reader.startDecoding().toList()])
-      .then((results) => results.last);
+      .then((results) => results.last as List<Frame>);
 }

--- a/test/src/ping/ping_handler_test.dart
+++ b/test/src/ping/ping_handler_test.dart
@@ -14,7 +14,7 @@ import '../error_matchers.dart';
 void main() {
   group('ping-handler', () {
     test('successful-ping', () async {
-      dynamic writer = FrameWriterMock();
+      var writer = FrameWriterMock();
       var pingHandler = PingHandler(writer);
 
       var p1 = pingHandler.ping();
@@ -36,7 +36,7 @@ void main() {
     });
 
     test('successful-ack-to-remote-ping', () async {
-      dynamic writer = FrameWriterMock();
+      var writer = FrameWriterMock();
       var pingHandler = PingHandler(writer);
 
       var header = FrameHeader(8, FrameType.PING, 0, 0);
@@ -52,7 +52,7 @@ void main() {
     });
 
     test('ping-unknown-opaque-data', () async {
-      dynamic writer = FrameWriterMock();
+      var writer = FrameWriterMock();
       var pingHandler = PingHandler(writer);
 
       var future = pingHandler.ping();

--- a/test/src/settings/settings_handler_test.dart
+++ b/test/src/settings/settings_handler_test.dart
@@ -18,7 +18,7 @@ void main() {
     var setMaxTable256 = [Setting(Setting.SETTINGS_HEADER_TABLE_SIZE, 256)];
 
     test('successful-setting', () async {
-      dynamic writer = FrameWriterMock();
+      var writer = FrameWriterMock();
       var sh = SettingsHandler(
           HPackEncoder(), writer, ActiveSettings(), ActiveSettings());
 
@@ -42,7 +42,7 @@ void main() {
     });
 
     test('ack-remote-settings-change', () {
-      dynamic writer = FrameWriterMock();
+      var writer = FrameWriterMock();
       var sh = SettingsHandler(
           HPackEncoder(), writer, ActiveSettings(), ActiveSettings());
 
@@ -91,8 +91,8 @@ void main() {
     });
 
     test('change-max-header-table-size', () {
-      dynamic writer = FrameWriterMock();
-      dynamic mock = HPackEncoderMock();
+      var writer = FrameWriterMock();
+      var mock = HPackEncoderMock();
       var sh =
           SettingsHandler(mock, writer, ActiveSettings(), ActiveSettings());
 

--- a/test/src/streams/streams_test.dart
+++ b/test/src/streams/streams_test.dart
@@ -19,7 +19,7 @@ void main() {
         sStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
           expect(msg is HeadersStreamMessage, isTrue);
 
-          HeadersStreamMessage headersMsg = msg;
+          var headersMsg = msg as HeadersStreamMessage;
           expectHeadersEqual(headersMsg.headers, expectedHeaders);
         }), onDone: expectAsync0(() {}));
         sStream.outgoingMessages.close();
@@ -40,7 +40,7 @@ void main() {
             expectAsync1((StreamMessage msg) {
               expect(msg is HeadersStreamMessage, isTrue);
 
-              HeadersStreamMessage headersMsg = msg;
+              var headersMsg = msg as HeadersStreamMessage;
               expectHeadersEqual(headersMsg.headers, expectedHeaders);
             }, count: 3),
             onDone: expectAsync0(() {}));
@@ -73,12 +73,12 @@ void main() {
                 isFirst = false;
                 expect(msg is HeadersStreamMessage, isTrue);
 
-                HeadersStreamMessage headersMsg = msg;
+                var headersMsg = msg as HeadersStreamMessage;
                 expectHeadersEqual(headersMsg.headers, expectedHeaders);
               } else {
                 expect(msg is DataStreamMessage, isTrue);
 
-                DataStreamMessage dataMsg = msg;
+                var dataMsg = msg as DataStreamMessage;
                 receivedChunks.add(dataMsg.bytes);
               }
             }, count: 1 + chunks.length), onDone: expectAsync0(() {
@@ -102,7 +102,7 @@ void main() {
         sStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
           expect(msg is HeadersStreamMessage, isTrue);
 
-          HeadersStreamMessage headersMsg = msg;
+          var headersMsg = msg as HeadersStreamMessage;
           expectHeadersEqual(headersMsg.headers, expectedHeaders);
         }), onDone: expectAsync0(() {}));
         sStream.sendHeaders(expectedHeaders, endStream: true);
@@ -114,7 +114,7 @@ void main() {
       cStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
         expect(msg is HeadersStreamMessage, isTrue);
 
-        HeadersStreamMessage headersMsg = msg;
+        var headersMsg = msg as HeadersStreamMessage;
         expectHeadersEqual(headersMsg.headers, expectedHeaders);
       }), onDone: expectAsync0(() {}));
     });
@@ -128,7 +128,7 @@ void main() {
         sStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
           expect(msg is HeadersStreamMessage, isTrue);
 
-          HeadersStreamMessage headersMsg = msg;
+          var headersMsg = msg as HeadersStreamMessage;
           expectHeadersEqual(headersMsg.headers, expectedHeaders);
         }), onDone: expectAsync0(() {}));
 
@@ -143,7 +143,7 @@ void main() {
       cStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
         expect(msg is HeadersStreamMessage, isTrue);
 
-        HeadersStreamMessage headersMsg = msg;
+        var headersMsg = msg as HeadersStreamMessage;
         expectHeadersEqual(headersMsg.headers, expectedHeaders);
       }, count: 3));
     });
@@ -162,7 +162,7 @@ void main() {
         sStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
           expect(msg is HeadersStreamMessage, isTrue);
 
-          HeadersStreamMessage headersMsg = msg;
+          var headersMsg = msg as HeadersStreamMessage;
           expectHeadersEqual(headersMsg.headers, expectedHeaders);
         }), onDone: expectAsync0(() {}));
 
@@ -197,14 +197,14 @@ void main() {
               expect(msg is HeadersStreamMessage, isTrue);
               expect(msg.endStream, false);
 
-              HeadersStreamMessage headersMsg = msg;
+              var headersMsg = msg as HeadersStreamMessage;
               expectHeadersEqual(headersMsg.headers, expectedHeaders);
             } else {
               expect(msg is DataStreamMessage, isTrue);
               expect(msg.endStream, true);
               expect(receivedChunk, null);
 
-              DataStreamMessage dataMsg = msg;
+              var dataMsg = msg as DataStreamMessage;
               receivedChunk = dataMsg.bytes;
             }
           }, count: 2), onDone: expectAsync0(() {

--- a/test/transport_test.dart
+++ b/test/transport_test.dart
@@ -126,7 +126,7 @@ void main() {
 
       Future serverFun() async {
         await for (ServerTransportStream stream in server.incomingStreams) {
-          var pushes = [];
+          var pushes = <ServerTransportStream>[];
           for (var i = 0; i < kDefaultStreamLimit; i++) {
             expect(stream.canPush, true);
             pushes.add(stream.push([Header.ascii('a', 'b')]));
@@ -139,7 +139,7 @@ void main() {
               throwsA(const TypeMatcher<StateError>()));
 
           // Finish the pushes
-          for (ServerTransportStream pushedStream in pushes) {
+          for (var pushedStream in pushes) {
             pushedStream
                 .sendHeaders([Header.ascii('e', 'nd')], endStream: true);
             await pushedStream.incomingMessages.toList();
@@ -471,7 +471,7 @@ void main() {
               gotHeadersFrame = true;
             } else {
               expect(message is DataStreamMessage, true);
-              DataStreamMessage dataMessage = message;
+              var dataMessage = message as DataStreamMessage;
 
               // We're just testing the first byte, to make the test faster.
               expect(dataMessage.bytes[0],


### PR DESCRIPTION
Makes the places where a cast error could happen more explicit.
In many places remove the explicit `dynamic` from variable declarations
to avoid throwing away type information that is valid.