### PR TITLE
Use isA type matcher in tests

### DIFF
--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -37,9 +37,10 @@ void main() {
           settingsDone.complete();
 
           // Make sure we get the graceful shutdown message.
-          var frame = await nextFrame();
-          expect(frame is GoawayFrame, true);
-          expect((frame as GoawayFrame).errorCode, ErrorCode.NO_ERROR);
+          expect(
+              await nextFrame(),
+              isA<GoawayFrame>()
+                  .having((f) => f.errorCode, 'errorCode', ErrorCode.NO_ERROR));
 
           // Make sure the client ended the connection.
           expect(await serverReader.moveNext(), false);
@@ -154,10 +155,13 @@ void main() {
           serverWriter.writeDataFrame(invalidStreamId, [42]);
 
           // Make sure the client sends a [RstStreamFrame] frame.
-          var frame = await nextFrame();
-          expect(frame is RstStreamFrame, true);
-          expect((frame as RstStreamFrame).errorCode, ErrorCode.STREAM_CLOSED);
-          expect((frame as RstStreamFrame).header.streamId, invalidStreamId);
+          expect(
+              await nextFrame(),
+              isA<RstStreamFrame>()
+                  .having(
+                      (f) => f.errorCode, 'errorCode', ErrorCode.STREAM_CLOSED)
+                  .having((f) => f.header.streamId, 'header.streamId',
+                      invalidStreamId));
 
           // Close the original stream.
           serverWriter.writeDataFrame(headers.header.streamId, [],
@@ -221,10 +225,13 @@ void main() {
           expect(win.windowSizeIncrement, 1);
 
           // Make sure we get a [RstStreamFrame] frame.
-          var frame = await nextFrame();
-          expect(frame is RstStreamFrame, true);
-          expect((frame as RstStreamFrame).errorCode, ErrorCode.STREAM_CLOSED);
-          expect((frame as RstStreamFrame).header.streamId, streamId);
+          expect(
+              await nextFrame(),
+              isA<RstStreamFrame>()
+                  .having(
+                      (f) => f.errorCode, 'errorCode', ErrorCode.STREAM_CLOSED)
+                  .having(
+                      (f) => f.header.streamId, 'header.streamId', streamId));
 
           // Wait for the client finish.
           expect(await nextFrame() is GoawayFrame, true);
@@ -290,10 +297,12 @@ void main() {
           expect(win.windowSizeIncrement, 1);
 
           // Make sure we get a [RstStreamFrame] frame.
-          var frame = await nextFrame();
-          expect(frame is RstStreamFrame, true);
-          expect((frame as RstStreamFrame).errorCode, ErrorCode.CANCEL);
-          expect((frame as RstStreamFrame).header.streamId, streamId);
+          expect(
+              await nextFrame(),
+              isA<RstStreamFrame>()
+                  .having((f) => f.errorCode, 'errorCode', ErrorCode.CANCEL)
+                  .having(
+                      (f) => f.header.streamId, 'header.streamId', streamId));
 
           serverWriter.writeRstStreamFrame(streamId, ErrorCode.STREAM_CLOSED);
 

--- a/test/multiprotocol_server_test.dart
+++ b/test/multiprotocol_server_test.dart
@@ -94,7 +94,7 @@ Future makeHttp2Request(MultiProtocolHttpServer server,
   var si = StreamIterator(stream.incomingMessages);
 
   expect(await si.moveNext(), true);
-  expect(si.current is HeadersStreamMessage, true);
+  expect(si.current, isA<HeadersStreamMessage>());
   var responseHeaders = getHeaders(si.current as HeadersStreamMessage);
   expect(responseHeaders[':status'], '200');
 
@@ -108,7 +108,7 @@ Future handleHttp2Request(ServerTransportStream stream, int i) async {
   var si = StreamIterator(stream.incomingMessages);
 
   expect(await si.moveNext(), true);
-  expect(si.current is HeadersStreamMessage, true);
+  expect(si.current, isA<HeadersStreamMessage>());
   var headers = getHeaders(si.current as HeadersStreamMessage);
 
   expect(headers[':path'], '/abc$i');

--- a/test/server_test.dart
+++ b/test/server_test.dart
@@ -61,9 +61,10 @@ void main() {
           clientWriter.writeHeadersFrame(1, [], endStream: true);
 
           // Make sure the client gets a [GoawayFrame] frame.
-          var frame = await nextFrame();
-          expect(frame is GoawayFrame, true);
-          expect((frame as GoawayFrame).errorCode, ErrorCode.PROTOCOL_ERROR);
+          expect(
+              await nextFrame(),
+              isA<GoawayFrame>().having(
+                  (f) => f.errorCode, 'errorCode', ErrorCode.PROTOCOL_ERROR));
 
           // Make sure the server ended the connection.
           expect(await clientReader.moveNext(), false);
@@ -92,10 +93,12 @@ void main() {
           clientWriter.writeDataFrame(3, [1, 2, 3]);
 
           // Make sure the client gets a [RstStreamFrame] frame.
-          var frame = await nextFrame();
-          expect(frame is RstStreamFrame, true);
-          expect((frame as RstStreamFrame).errorCode, ErrorCode.STREAM_CLOSED);
-          expect((frame as RstStreamFrame).header.streamId, 3);
+          expect(
+              await nextFrame(),
+              isA<RstStreamFrame>()
+                  .having(
+                      (f) => f.errorCode, 'errorCode', ErrorCode.STREAM_CLOSED)
+                  .having((f) => f.header.streamId, 'header.streamId', 3));
 
           // Tell the server to finish.
           clientWriter.writeGoawayFrame(3, ErrorCode.NO_ERROR, []);
@@ -131,10 +134,12 @@ void main() {
           clientWriter.writeDataFrame(3, [1, 2, 3]);
 
           // Make sure the client gets a [RstStreamFrame] frame.
-          var frame = await nextFrame();
-          expect(frame is RstStreamFrame, true);
-          expect((frame as RstStreamFrame).errorCode, ErrorCode.STREAM_CLOSED);
-          expect((frame as RstStreamFrame).header.streamId, 3);
+          expect(
+              await nextFrame(),
+              isA<RstStreamFrame>()
+                  .having(
+                      (f) => f.errorCode, 'errorCode', ErrorCode.STREAM_CLOSED)
+                  .having((f) => f.header.streamId, 'header.streamId', 3));
 
           // Tell the server to finish.
           clientWriter.writeGoawayFrame(3, ErrorCode.NO_ERROR, []);
@@ -174,10 +179,11 @@ void main() {
               endStream: false);
 
           // Make sure the client gets a [RstStreamFrame] frame.
-          var frame = await nextFrame();
-          expect(frame is RstStreamFrame, true);
-          expect((frame as RstStreamFrame).errorCode, ErrorCode.CANCEL);
-          expect((frame as RstStreamFrame).header.streamId, 1);
+          expect(
+              await nextFrame(),
+              isA<RstStreamFrame>()
+                  .having((f) => f.errorCode, 'errorCode', ErrorCode.CANCEL)
+                  .having((f) => f.header.streamId, 'header.streamId', 1));
 
           // Tell the server to finish.
           clientWriter.writeGoawayFrame(3, ErrorCode.NO_ERROR, []);

--- a/test/src/flowcontrol/stream_queues_test.dart
+++ b/test/src/flowcontrol/stream_queues_test.dart
@@ -99,7 +99,7 @@ void main() {
 
         expect(queue.pendingMessages, 0);
         queue.messages.listen(expectAsync1((StreamMessage message) {
-          expect(message is DataStreamMessage, isTrue);
+          expect(message, isA<DataStreamMessage>());
 
           var dataMessage = message as DataStreamMessage;
           expect(dataMessage.bytes, BYTES);

--- a/test/src/frames/frame_reader_test.dart
+++ b/test/src/frames/frame_reader_test.dart
@@ -37,7 +37,7 @@ void main() {
       test('data-frame--max-frame-size', () {
         var body = List.filled(maxFrameSize, 0x42);
         dataFrame(body).listen(expectAsync1((Frame frame) {
-          expect(frame is DataFrame, isTrue);
+          expect(frame, isA<DataFrame>());
           expect(frame.header, hasLength(body.length));
           expect(frame.header.flags, 0);
           var dataFrame = frame as DataFrame;

--- a/test/src/streams/simple_flow_test.dart
+++ b/test/src/streams/simple_flow_test.dart
@@ -20,11 +20,13 @@ void main() {
 
       void Function(StreamMessage) headersTestFun(String type) {
         return expectAsync1((StreamMessage msg) {
-          expect(msg is HeadersStreamMessage, isTrue);
-          expect((msg as HeadersStreamMessage).headers.first.name,
-              expectedHeaders.first.name);
-          expect((msg as HeadersStreamMessage).headers.first.value,
-              expectedHeaders.first.value);
+          expect(
+              msg,
+              isA<HeadersStreamMessage>()
+                  .having((m) => m.headers.first.name, 'headers.first.name',
+                      expectedHeaders.first.name)
+                  .having((m) => m.headers.first.value, 'headers.first.value',
+                      expectedHeaders.first.value));
         });
       }
 
@@ -36,13 +38,15 @@ void main() {
         return (StreamMessage msg) {
           if (expectHeader) {
             expectHeader = false;
-            expect(msg is HeadersStreamMessage, isTrue);
-            expect((msg as HeadersStreamMessage).headers.first.name,
-                expectedHeaders.first.name);
-            expect((msg as HeadersStreamMessage).headers.first.value,
-                expectedHeaders.first.value);
+            expect(
+                msg,
+                isA<HeadersStreamMessage>()
+                    .having((m) => m.headers.first.name, 'headers.first.name',
+                        expectedHeaders.first.name)
+                    .having((m) => m.headers.first.value, 'headers.first.value',
+                        expectedHeaders.first.value));
           } else {
-            expect(msg is DataStreamMessage, isTrue);
+            expect(msg, isA<DataStreamMessage>());
             var bytes = (msg as DataStreamMessage).bytes;
             expect(
                 bytes,

--- a/test/src/streams/simple_push_test.dart
+++ b/test/src/streams/simple_push_test.dart
@@ -30,7 +30,7 @@ void main() {
 
       void Function(StreamMessage) headersTestFun() {
         return expectAsync1((StreamMessage msg) {
-          expect(msg is HeadersStreamMessage, isTrue);
+          expect(msg, isA<HeadersStreamMessage>());
           testHeaders((msg as HeadersStreamMessage).headers);
         });
       }
@@ -42,7 +42,7 @@ void main() {
 
         while (await iterator.moveNext()) {
           var msg = iterator.current;
-          expect(msg is DataStreamMessage, isTrue);
+          expect(msg, isA<DataStreamMessage>());
           all.addAll((msg as DataStreamMessage).bytes);
         }
 

--- a/test/src/streams/streams_test.dart
+++ b/test/src/streams/streams_test.dart
@@ -17,7 +17,7 @@ void main() {
 
       server.incomingStreams.listen(expectAsync1((TransportStream sStream) {
         sStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
-          expect(msg is HeadersStreamMessage, isTrue);
+          expect(msg, isA<HeadersStreamMessage>());
 
           var headersMsg = msg as HeadersStreamMessage;
           expectHeadersEqual(headersMsg.headers, expectedHeaders);
@@ -38,7 +38,7 @@ void main() {
       server.incomingStreams.listen(expectAsync1((TransportStream sStream) {
         sStream.incomingMessages.listen(
             expectAsync1((StreamMessage msg) {
-              expect(msg is HeadersStreamMessage, isTrue);
+              expect(msg, isA<HeadersStreamMessage>());
 
               var headersMsg = msg as HeadersStreamMessage;
               expectHeadersEqual(headersMsg.headers, expectedHeaders);
@@ -71,12 +71,12 @@ void main() {
             expectAsync1((StreamMessage msg) {
               if (isFirst) {
                 isFirst = false;
-                expect(msg is HeadersStreamMessage, isTrue);
+                expect(msg, isA<HeadersStreamMessage>());
 
                 var headersMsg = msg as HeadersStreamMessage;
                 expectHeadersEqual(headersMsg.headers, expectedHeaders);
               } else {
-                expect(msg is DataStreamMessage, isTrue);
+                expect(msg, isA<DataStreamMessage>());
 
                 var dataMsg = msg as DataStreamMessage;
                 receivedChunks.add(dataMsg.bytes);
@@ -100,7 +100,7 @@ void main() {
 
       server.incomingStreams.listen(expectAsync1((TransportStream sStream) {
         sStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
-          expect(msg is HeadersStreamMessage, isTrue);
+          expect(msg, isA<HeadersStreamMessage>());
 
           var headersMsg = msg as HeadersStreamMessage;
           expectHeadersEqual(headersMsg.headers, expectedHeaders);
@@ -112,7 +112,7 @@ void main() {
           client.makeRequest(expectedHeaders, endStream: true);
 
       cStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
-        expect(msg is HeadersStreamMessage, isTrue);
+        expect(msg, isA<HeadersStreamMessage>());
 
         var headersMsg = msg as HeadersStreamMessage;
         expectHeadersEqual(headersMsg.headers, expectedHeaders);
@@ -126,7 +126,7 @@ void main() {
 
       server.incomingStreams.listen(expectAsync1((TransportStream sStream) {
         sStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
-          expect(msg is HeadersStreamMessage, isTrue);
+          expect(msg, isA<HeadersStreamMessage>());
 
           var headersMsg = msg as HeadersStreamMessage;
           expectHeadersEqual(headersMsg.headers, expectedHeaders);
@@ -141,7 +141,7 @@ void main() {
           client.makeRequest(expectedHeaders, endStream: true);
 
       cStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
-        expect(msg is HeadersStreamMessage, isTrue);
+        expect(msg, isA<HeadersStreamMessage>());
 
         var headersMsg = msg as HeadersStreamMessage;
         expectHeadersEqual(headersMsg.headers, expectedHeaders);
@@ -160,7 +160,7 @@ void main() {
 
       server.incomingStreams.listen(expectAsync1((TransportStream sStream) {
         sStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
-          expect(msg is HeadersStreamMessage, isTrue);
+          expect(msg, isA<HeadersStreamMessage>());
 
           var headersMsg = msg as HeadersStreamMessage;
           expectHeadersEqual(headersMsg.headers, expectedHeaders);
@@ -175,8 +175,10 @@ void main() {
 
       var i = 0;
       cStream.incomingMessages.listen(expectAsync1((StreamMessage msg) {
-        expect(msg is DataStreamMessage, isTrue);
-        expect((msg as DataStreamMessage).bytes, chunks[i++]);
+        expect(
+            msg,
+            isA<DataStreamMessage>()
+                .having((m) => m.bytes, 'bytes', chunks[i++]));
       }, count: chunks.length));
     });
   });
@@ -194,13 +196,13 @@ void main() {
           expectAsync1((StreamMessage msg) {
             if (isFirst) {
               isFirst = false;
-              expect(msg is HeadersStreamMessage, isTrue);
+              expect(msg, isA<HeadersStreamMessage>());
               expect(msg.endStream, false);
 
               var headersMsg = msg as HeadersStreamMessage;
               expectHeadersEqual(headersMsg.headers, expectedHeaders);
             } else {
-              expect(msg is DataStreamMessage, isTrue);
+              expect(msg, isA<DataStreamMessage>());
               expect(msg.endStream, true);
               expect(receivedChunk, null);
 

--- a/test/transport_test.dart
+++ b/test/transport_test.dart
@@ -23,7 +23,7 @@ void main() {
     transportTest('terminated-client-ping',
         (TransportConnection client, TransportConnection server) async {
       var clientError = client.ping().catchError(expectAsync2((e, s) {
-        expect(e is TransportException, isTrue);
+        expect(e, isA<TransportException>());
       }));
       await client.terminate();
       await clientError;
@@ -31,17 +31,17 @@ void main() {
       // NOTE: Now the connection is dead and client/server should complete
       // with [TransportException]s when doing work (e.g. ping).
       unawaited(client.ping().catchError(expectAsync2((e, s) {
-        expect(e is TransportException, isTrue);
+        expect(e, isA<TransportException>());
       })));
       unawaited(server.ping().catchError(expectAsync2((e, s) {
-        expect(e is TransportException, isTrue);
+        expect(e, isA<TransportException>());
       })));
     });
 
     transportTest('terminated-server-ping',
         (TransportConnection client, TransportConnection server) async {
       var clientError = client.ping().catchError(expectAsync2((e, s) {
-        expect(e is TransportException, isTrue);
+        expect(e, isA<TransportException>());
       }));
       await server.terminate();
       await clientError;
@@ -49,10 +49,10 @@ void main() {
       // NOTE: Now the connection is dead and the client/server should complete
       // with [TransportException]s when doing work (e.g. ping).
       unawaited(client.ping().catchError(expectAsync2((e, s) {
-        expect(e is TransportException, isTrue);
+        expect(e, isA<TransportException>());
       })));
       unawaited(server.ping().catchError(expectAsync2((e, s) {
-        expect(e is TransportException, isTrue);
+        expect(e, isA<TransportException>());
       })));
     });
 
@@ -221,7 +221,7 @@ void main() {
         await for (ServerTransportStream stream in server.incomingStreams) {
           stream.sendHeaders([Header.ascii('x', 'y')], endStream: true);
           stream.incomingMessages.listen(expectAsync1((msg) {
-            expect(msg is HeadersStreamMessage, true);
+            expect(msg, isA<HeadersStreamMessage>());
             readyForError.complete();
           }), onError: expectAsync1((error) {
             expect('$error', contains('Stream was terminated by peer'));
@@ -275,7 +275,7 @@ void main() {
           stream.sendHeaders([Header.ascii('x', 'y')], endStream: false);
           stream.incomingMessages.listen(
             expectAsync1((msg) {
-              expect(msg is HeadersStreamMessage, true);
+              expect(msg, isA<HeadersStreamMessage>());
             }),
             onError: expectAsync1((_) {}, count: 0),
             onDone: expectAsync0(() {
@@ -308,7 +308,7 @@ void main() {
           stream.sendHeaders([Header.ascii('x', 'y')], endStream: false);
           stream.incomingMessages.listen(
             expectAsync1((msg) async {
-              expect(msg is HeadersStreamMessage, true);
+              expect(msg, isA<HeadersStreamMessage>());
               await readyForError.future;
               stream.terminate();
             }),
@@ -467,10 +467,10 @@ void main() {
 
           var sub = stream.incomingMessages.listen((message) {
             if (!gotHeadersFrame) {
-              expect(message is HeadersStreamMessage, true);
+              expect(message, isA<HeadersStreamMessage>());
               gotHeadersFrame = true;
             } else {
-              expect(message is DataStreamMessage, true);
+              expect(message, isA<DataStreamMessage>());
               var dataMessage = message as DataStreamMessage;
 
               // We're just testing the first byte, to make the test faster.


### PR DESCRIPTION
The failure output is nicer when using a TypeMatcher over using an `is`
check and comparing against the boolean `true`.