### PR TITLE
Add TransportConnection.onInitialPeerSettingsReceived

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.0.1-dev
 
+* Add `TransportConnection.onInitialPeerSettingsReceived` which fires when
+  intial SETTINGS frame is received from the peer.
+
 ## 1.0.0
 
 * Graduate package to 1.0.

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -97,6 +97,12 @@ abstract class Connection {
   /// Active state handler for this connection.
   ActiveStateHandler onActiveStateChanged;
 
+  final Completer<void> _onConnectionOperational = Completer<void>();
+
+  /// Future which completes when connection becomes operational after
+  /// we receive the initial SETTINGS frame from the other side.
+  Future<void> get onConnectionOperational => _onConnectionOperational.future;
+
   /// The HPack context for this connection.
   final HPackContext _hpackContext = HPackContext();
 
@@ -322,6 +328,7 @@ abstract class Connection {
         return;
       }
       _state.state = ConnectionState.Operational;
+      _onConnectionOperational.complete();
     }
 
     // Try to defragment [frame] if it is a Headers/PushPromise frame.

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -97,11 +97,12 @@ abstract class Connection {
   /// Active state handler for this connection.
   ActiveStateHandler onActiveStateChanged;
 
-  final Completer<void> _onConnectionOperational = Completer<void>();
+  final Completer<void> _onInitialPeerSettingsReceived = Completer<void>();
 
-  /// Future which completes when connection becomes operational after
-  /// we receive the initial SETTINGS frame from the other side.
-  Future<void> get onConnectionOperational => _onConnectionOperational.future;
+  /// Future which completes when the first SETTINGS frame is received from
+  /// the peer.
+  Future<void> get onInitialPeerSettingsReceived =>
+      _onInitialPeerSettingsReceived.future;
 
   /// The HPack context for this connection.
   final HPackContext _hpackContext = HPackContext();
@@ -328,7 +329,7 @@ abstract class Connection {
         return;
       }
       _state.state = ConnectionState.Operational;
-      _onConnectionOperational.complete();
+      _onInitialPeerSettingsReceived.complete();
     }
 
     // Try to defragment [frame] if it is a Headers/PushPromise frame.

--- a/lib/transport.dart
+++ b/lib/transport.dart
@@ -60,9 +60,9 @@ abstract class TransportConnection {
   /// from active to idle).
   set onActiveStateChanged(ActiveStateHandler callback);
 
-  /// Future which completes when connection becomes operational after
-  /// the first SETTINGS frame is received from the other side.
-  Future<void> get onConnectionOperational;
+  /// Future which completes when the first SETTINGS frame is received from
+  /// the peer.
+  Future<void> get onInitialPeerSettingsReceived;
 
   /// Finish this connection.
   ///

--- a/lib/transport.dart
+++ b/lib/transport.dart
@@ -10,6 +10,8 @@ import 'src/hpack/hpack.dart' show Header;
 
 export 'src/hpack/hpack.dart' show Header;
 
+typedef OperationalStateHandler = void Function();
+
 typedef ActiveStateHandler = void Function(bool isActive);
 
 /// Settings for a [TransportConnection].
@@ -59,6 +61,10 @@ abstract class TransportConnection {
   /// `false` when the number of active streams becomes 0 (the connection goes
   /// from active to idle).
   set onActiveStateChanged(ActiveStateHandler callback);
+
+  /// Future which completes when connection becomes operational after
+  /// the first SETTINGS frame is received from the other side.
+  Future<void> get onConnectionOperational;
 
   /// Finish this connection.
   ///

--- a/lib/transport.dart
+++ b/lib/transport.dart
@@ -10,8 +10,6 @@ import 'src/hpack/hpack.dart' show Header;
 
 export 'src/hpack/hpack.dart' show Header;
 
-typedef OperationalStateHandler = void Function();
-
 typedef ActiveStateHandler = void Function(bool isActive);
 
 /// Settings for a [TransportConnection].

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -63,6 +63,90 @@ void main() {
       });
     });
 
+    group('connection-operational', () {
+      clientTest('on-connection-operational-fires',
+          (ClientTransportConnection client,
+              FrameWriter serverWriter,
+              StreamIterator<Frame> serverReader,
+              Future<Frame> Function() nextFrame) async {
+        var settingsDone = Completer();
+
+        Future serverFun() async {
+          serverWriter.writeSettingsFrame([]);
+          expect(await nextFrame() is SettingsFrame, true);
+          serverWriter.writeSettingsAckFrame();
+          expect(await nextFrame() is SettingsFrame, true);
+
+          settingsDone.complete();
+
+          // Make sure we get the graceful shutdown message.
+          expect(
+              await nextFrame(),
+              isA<GoawayFrame>()
+                  .having((f) => f.errorCode, 'errorCode', ErrorCode.NO_ERROR));
+
+          // Make sure the client ended the connection.
+          expect(await serverReader.moveNext(), false);
+        }
+
+        Future clientFun() async {
+          await settingsDone.future;
+          await client.onConnectionOperational; // Should complete
+
+          expect(client.isOpen, true);
+
+          // Try to gracefully finish the connection.
+          var future = client.finish();
+
+          expect(client.isOpen, false);
+
+          await future;
+        }
+
+        await Future.wait([serverFun(), clientFun()]);
+      });
+
+      clientTest('on-connection-operational-does-not-fire',
+          (ClientTransportConnection client,
+              FrameWriter serverWriter,
+              StreamIterator<Frame> serverReader,
+              Future<Frame> Function() nextFrame) async {
+        var goawayReceived = Completer();
+        Future serverFun() async {
+          serverWriter.writePingFrame(42);
+          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame() is GoawayFrame, true);
+          goawayReceived.complete();
+          expect(await serverReader.moveNext(), false);
+        }
+
+        Future clientFun() async {
+          expect(client.isOpen, true);
+
+          expect(client.onConnectionOperational.timeout(Duration(seconds: 1)),
+              throwsA(isA<TimeoutException>()));
+
+          // We wait until the server received the error (it's actually later
+          // than necessary, but we can't make a deterministic test otherwise).
+          await goawayReceived.future;
+
+          expect(client.isOpen, false);
+
+          var error;
+          try {
+            client.makeRequest([Header.ascii('a', 'b')]);
+          } catch (e) {
+            error = '$e';
+          }
+          expect(error, contains('no longer active'));
+
+          await client.finish();
+        }
+
+        await Future.wait([serverFun(), clientFun()]);
+      });
+    });
+
     group('server-errors', () {
       clientTest('no-settings-frame-at-beginning-immediate-error',
           (ClientTransportConnection client,


### PR DESCRIPTION
This allows to detect when settings frame was received from the server
thus avoiding any sort of hacks with artificial delays that clients 
were previously resorting to.

This does of course resolve a general problem of potential races
between server updating settings and client starting to honor them.
