### PR TITLE
Fix deprecated API usage, bump minimum SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-  - 2.5.0
+  - 2.8.4
   - dev
 
 dart_task:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.0.2-dev
 
+* Update minimum Dart SDK to `2.8.4`.
+
 ## 1.0.1
 
 * Add `TransportConnection.onInitialPeerSettingsReceived` which fires when

--- a/experimental/server.dart
+++ b/experimental/server.dart
@@ -26,9 +26,9 @@ void main() async {
   var server = await SecureServerSocket.bind(HOSTNAME, PORT, context);
   print('HTTP/2 server listening on https://$HOSTNAME:$PORT');
 
-  runZoned(() {
+  runZonedGuarded(() {
     server.listen(handleClient);
-  }, onError: (e, s) {
+  }, (e, s) {
     print('Unexpected error: $e');
     print('Unexpected error - stack: $s');
   });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: http2
 version: 1.0.2-dev
 description: A HTTP/2 implementation in Dart.
-homepage: https://github.com/dart-lang/http2
+repository: https://github.com/dart-lang/http2
 
 environment:
-  sdk: '>=2.5.0 <3.0.0'
+  sdk: '>=2.8.4 <3.0.0'
 
 dev_dependencies:
   mockito: ^4.0.0


### PR DESCRIPTION
runZoned `onError` is deprecated. Moved to `runZonedGuarded ` which was introduced in 2.8