### PR TITLE
Ditch dart:io import for dart:typed_data

### DIFF
--- a/lib/src/hpack/huffman.dart
+++ b/lib/src/hpack/huffman.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
+import 'dart:typed_data';
 
 import 'huffman_table.dart';
 


### PR DESCRIPTION
`BytesBuilder` is defined in `dart:typed_data` but currently `dart:io` is imported to import the mentioned class.

This is causing the package not working/supporting web and js platforms.

From this link https://pub.dev/packages/http2/score:

10/20 points: Supports 1 of 2 possible platforms (native, js)
Consider supporting multiple platforms:

Package not compatible with runtime js
Because:

- package:http2/http2.dart that imports:
- package:http2/transport.dart that imports:
- package:http2/src/hpack/hpack.dart that imports:
- package:http2/src/hpack/huffman_table.dart that imports:
- package:http2/src/hpack/huffman.dart that imports:
- dart:io