### PR TITLE
Package description should be at least 60 characters long.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: http2
 version: 2.0.0
-description: A HTTP/2 implementation in Dart.
+description: A HTTP/2 implementation in Dart supporting native and js platforms.
 repository: https://github.com/dart-lang/http2
 
 environment:


### PR DESCRIPTION
From https://pub.dev/packages/http2/score we see 10 less score for too short package description.

I did few wordings and made it 67 chars long.