### PR TITLE
Use `flutter_lints` package instead of `pedantic`.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,13 @@
-include: package:pedantic/analysis_options.yaml
+# This file configures the analyzer, which statically analyzes Dart code to
+# check for errors, warnings, and lints.
+#
+# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
+# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
+# invoked from the command line by running `flutter analyze`.
+
+# The following line activates a set of recommended lints for Flutter apps,
+# packages, and plugins designed to encourage good coding practices.
+include: package:flutter_lints/flutter.yaml
 
 analyzer:
   strong-mode:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,4 +10,10 @@ dev_dependencies:
   build_runner: ^1.10.0
   mockito: ^5.0.0-nullsafety
   test: ^1.16.0
-  pedantic: ^1.10.0
+  
+  # The "flutter_lints" package below contains a set of recommended lints to
+  # encourage good coding practices. The lint set provided by the package is
+  # activated in the `analysis_options.yaml` file located at the root of your
+  # package. See that file for information about deactivating specific lint
+  # rules and activating additional ones.
+  flutter_lints: ^1.0.0


### PR DESCRIPTION
If we create a new project with a recent version of flutter (`flutter create my_project`) we'd find out flutter is replacing `pedantic` package with `flutter_lints`.

It provides better lints.