### PR TITLE
Migrate to null-safety stable.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A HTTP/2 implementation in Dart.
 repository: https://github.com/dart-lang/http2
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dev_dependencies:
   build_runner: ^1.10.0


### PR DESCRIPTION
Flutter 2.0 is out for a while now and we can switch to stable null-safety.