### PR TITLE
Fix hint related to importing BytesBuilder from dart:io

### DIFF
--- a/lib/src/async_utils/async_utils.dart
+++ b/lib/src/async_utils/async_utils.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
+import 'dart:typed_data';
 
 /// An interface for `StreamSink`-like classes to indicate whether adding data
 /// would be buffered and when the buffer is empty again.

--- a/lib/src/hpack/hpack.dart
+++ b/lib/src/hpack/hpack.dart
@@ -8,7 +8,7 @@
 library http2.hpack;
 
 import 'dart:convert' show ascii;
-import 'dart:io';
+import 'dart:typed_data';
 
 import '../byte_utils.dart';
 


### PR DESCRIPTION
Switch to dart:typed_data
