### PR TITLE
Send WINDOW_UPDATE frames for data on closed streams.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.0.2-dev
 
 - Require Dart `2.17.0`.
+- Send `WINDOW_UPDATE` frames for the connection to account for data being sent on closed streams until the `RST_STREAM` has been processed.
 
 ## 2.0.1
 

--- a/lib/src/flowcontrol/connection_queues.dart
+++ b/lib/src/flowcontrol/connection_queues.dart
@@ -260,7 +260,7 @@ class ConnectionMessageQueueIn extends Object
   /// If a [DataFrame] will be ignored, this method will take the minimal
   /// action necessary.
   void processIgnoredDataFrame(DataFrame frame) {
-    _windowUpdateHandler.gotData(frame.bytes.length);
+    _windowUpdateHandler.dataProcessed(frame.bytes.length);
   }
 
   /// Processes an incoming [HeadersFrame] which is addressed to a specific

--- a/lib/src/streams/stream_handler.dart
+++ b/lib/src/streams/stream_handler.dart
@@ -536,10 +536,6 @@ class StreamHandler extends Object with TerminatableMixin, ClosableMixin {
           _highestStreamIdReceived =
               max(_highestStreamIdReceived, frame.header.streamId);
         }
-        var streamClosedException = StreamClosedException(
-            frame.header.streamId,
-            'No open stream found and was not a headers frame opening a '
-            'new stream.');
 
         if (frame is HeadersFrame) {
           if (isServer) {
@@ -614,9 +610,9 @@ class StreamHandler extends Object with TerminatableMixin, ClosableMixin {
           //     different.
           incomingQueue.processIgnoredDataFrame(frame);
           // Still respond with an error, as the stream is closed.
-          throw streamClosedException;
+          throw _throwStreamClosedException(frame.header.streamId);
         } else {
-          throw streamClosedException;
+          throw _throwStreamClosedException(frame.header.streamId);
         }
       } else {
         if (frame is HeadersFrame) {
@@ -887,4 +883,11 @@ class StreamHandler extends Object with TerminatableMixin, ClosableMixin {
     var id = stream.id;
     return (isServer && id.isEven) || (!isServer && id.isOdd);
   }
+
+  static Exception _throwStreamClosedException(int streamId) =>
+      StreamClosedException(
+        streamId,
+        'No open stream found and was not a headers frame opening a '
+        'new stream.',
+      );
 }

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -28,9 +28,9 @@ void main() {
 
         Future serverFun() async {
           serverWriter.writeSettingsFrame([]);
-          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
           serverWriter.writeSettingsAckFrame();
-          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
 
           settingsDone.complete();
 
@@ -72,9 +72,9 @@ void main() {
         Future serverFun() async {
           serverWriter.writeSettingsFrame([]);
           settingsDone.complete();
-          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
           serverWriter.writeSettingsAckFrame();
-          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
 
           // Make sure we get the graceful shutdown message.
           expect(
@@ -112,8 +112,8 @@ void main() {
         final goawayReceived = Completer();
         Future serverFun() async {
           serverWriter.writePingFrame(42);
-          expect(await nextFrame() is SettingsFrame, true);
-          expect(await nextFrame() is GoawayFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
+          expect(await nextFrame(), isA<GoawayFrame>());
           goawayReceived.complete();
           expect(await serverReader.moveNext(), false);
         }
@@ -156,8 +156,8 @@ void main() {
         var goawayReceived = Completer();
         Future serverFun() async {
           serverWriter.writePingFrame(42);
-          expect(await nextFrame() is SettingsFrame, true);
-          expect(await nextFrame() is GoawayFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
+          expect(await nextFrame(), isA<GoawayFrame>());
           goawayReceived.complete();
           expect(await serverReader.moveNext(), false);
         }
@@ -191,10 +191,10 @@ void main() {
               StreamIterator<Frame> serverReader,
               Future<Frame> Function() nextFrame) async {
         Future serverFun() async {
-          expect(await nextFrame() is SettingsFrame, true);
-          expect(await nextFrame() is HeadersFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
+          expect(await nextFrame(), isA<HeadersFrame>());
           serverWriter.writePingFrame(42);
-          expect(await nextFrame() is GoawayFrame, true);
+          expect(await nextFrame(), isA<GoawayFrame>());
           expect(await serverReader.moveNext(), false);
         }
 
@@ -224,23 +224,27 @@ void main() {
 
         Future serverFun() async {
           serverWriter.writeSettingsFrame([]);
-          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
           serverWriter.writeSettingsAckFrame();
-          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
 
           handshakeCompleter.complete();
 
           var headers = await nextFrame() as HeadersFrame;
-          var finFrame = await nextFrame() as DataFrame;
-          expect(finFrame.hasEndStreamFlag, true);
+          expect(
+              await nextFrame(),
+              isA<DataFrame>().having(
+                  (p0) => p0.hasEndStreamFlag, 'Last data frame', true));
 
           // Write a data frame for a non-existent stream.
           var invalidStreamId = headers.header.streamId + 2;
           serverWriter.writeDataFrame(invalidStreamId, [42]);
 
           // Make sure the client sends a [RstStreamFrame] frame.
-          var windowUpdateFrame = await nextFrame() as WindowUpdateFrame;
-          expect(windowUpdateFrame.header.streamId, 0);
+          expect(
+              await nextFrame(),
+              isA<WindowUpdateFrame>()
+                  .having((p0) => p0.header.streamId, 'Connection update', 0));
           expect(
               await nextFrame(),
               isA<RstStreamFrame>()
@@ -254,7 +258,7 @@ void main() {
               endStream: true);
 
           // Wait for the client finish.
-          expect(await nextFrame() is GoawayFrame, true);
+          expect(await nextFrame(), isA<GoawayFrame>());
           expect(await serverReader.moveNext(), false);
           await serverWriter.close();
         }
@@ -281,15 +285,17 @@ void main() {
 
         Future serverFun() async {
           serverWriter.writeSettingsFrame([]);
-          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
           serverWriter.writeSettingsAckFrame();
-          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
 
           handshakeCompleter.complete();
 
           var headers = await nextFrame() as HeadersFrame;
-          var finFrame = await nextFrame() as DataFrame;
-          expect(finFrame.hasEndStreamFlag, true);
+          expect(
+              await nextFrame(),
+              isA<DataFrame>().having(
+                  (p0) => p0.hasEndStreamFlag, 'Last data frame', true));
 
           var streamId = headers.header.streamId;
 
@@ -305,18 +311,28 @@ void main() {
           // happens to be like that ATM.
 
           // The two WindowUpdateFrames for the data1 DataFrame.
-          var streamUpdate = await nextFrame() as WindowUpdateFrame;
-          expect(streamUpdate.header.streamId, 1);
-          expect(streamUpdate.windowSizeIncrement, 2);
-          var connectionUpdate = await nextFrame() as WindowUpdateFrame;
-          expect(connectionUpdate.header.streamId, 0);
-          expect(connectionUpdate.windowSizeIncrement, 2);
+          expect(
+              await nextFrame(),
+              isA<WindowUpdateFrame>()
+                  .having((p0) => p0.header.streamId, 'Stream update', 1)
+                  .having((p0) => p0.windowSizeIncrement, 'Windowsize',
+                      data1.length));
+
+          expect(
+              await nextFrame(),
+              isA<WindowUpdateFrame>()
+                  .having((p0) => p0.header.streamId, 'Connection update', 0)
+                  .having((p0) => p0.windowSizeIncrement, 'Windowsize',
+                      data1.length));
 
           // The [WindowUpdateFrame] for the frame on the closed stream, which
           // should still update the connection.
-          var connectionUpdate2 = await nextFrame() as WindowUpdateFrame;
-          expect(connectionUpdate2.header.streamId, 0);
-          expect(connectionUpdate2.windowSizeIncrement, 1);
+          expect(
+              await nextFrame(),
+              isA<WindowUpdateFrame>()
+                  .having((p0) => p0.header.streamId, 'Connection update', 0)
+                  .having((p0) => p0.windowSizeIncrement, 'Windowsize',
+                      data2.length));
 
           // Make sure we get a [RstStreamFrame] frame.
           expect(
@@ -328,7 +344,7 @@ void main() {
                       (f) => f.header.streamId, 'header.streamId', streamId));
 
           // Wait for the client finish.
-          expect(await nextFrame() is GoawayFrame, true);
+          expect(await nextFrame(), isA<GoawayFrame>());
           expect(await serverReader.moveNext(), false);
           await serverWriter.close();
         }
@@ -340,7 +356,11 @@ void main() {
           await stream.outgoingMessages.close();
           var messages = await stream.incomingMessages.toList();
           expect(messages, hasLength(1));
-          expect((messages[0] as DataStreamMessage).bytes, [42, 42]);
+          expect(
+            messages[0],
+            isA<DataStreamMessage>()
+                .having((p0) => p0.bytes, 'Same as `data1` above', [42, 42]),
+          );
 
           await client.finish();
         }
@@ -359,16 +379,17 @@ void main() {
 
         Future serverFun() async {
           serverWriter.writeSettingsFrame([]);
-          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
           serverWriter.writeSettingsAckFrame();
-          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
 
           handshakeCompleter.complete();
 
           var headers = await nextFrame() as HeadersFrame;
-          var finFrame = await nextFrame() as DataFrame;
-          expect(finFrame.hasEndStreamFlag, true);
-
+          expect(
+              await nextFrame(),
+              isA<DataFrame>().having(
+                  (p0) => p0.hasEndStreamFlag, 'Last data frame', true));
           var streamId = headers.header.streamId;
 
           // Write a data frame.
@@ -380,15 +401,21 @@ void main() {
           // happens to be like that ATM.
 
           // Await stream/connection window update frame.
-          var win = await nextFrame() as WindowUpdateFrame;
-          expect(win.header.streamId, 1);
-          expect(win.windowSizeIncrement, 1);
-          win = await nextFrame() as WindowUpdateFrame;
-          expect(win.header.streamId, 0);
-          expect(win.windowSizeIncrement, 1);
-          win = await nextFrame() as WindowUpdateFrame;
-          expect(win.header.streamId, 0);
-          expect(win.windowSizeIncrement, 1);
+          expect(
+              await nextFrame(),
+              isA<WindowUpdateFrame>()
+                  .having((p0) => p0.header.streamId, 'Stream update', 1)
+                  .having((p0) => p0.windowSizeIncrement, 'Windowsize', 1));
+          expect(
+              await nextFrame(),
+              isA<WindowUpdateFrame>()
+                  .having((p0) => p0.header.streamId, 'Connection update', 0)
+                  .having((p0) => p0.windowSizeIncrement, 'Windowsize', 1));
+          expect(
+              await nextFrame(),
+              isA<WindowUpdateFrame>()
+                  .having((p0) => p0.header.streamId, 'Connection update', 0)
+                  .having((p0) => p0.windowSizeIncrement, 'Windowsize', 1));
 
           // Make sure we get a [RstStreamFrame] frame.
           expect(
@@ -403,7 +430,7 @@ void main() {
           endDone.complete();
 
           // Wait for the client finish.
-          expect(await nextFrame() is GoawayFrame, true);
+          expect(await nextFrame(), isA<GoawayFrame>());
           expect(await serverReader.moveNext(), false);
           await serverWriter.close();
         }
@@ -416,7 +443,12 @@ void main() {
 
           // first will cancel the stream
           var message = await stream.incomingMessages.first;
-          expect((message as DataStreamMessage).bytes, [42]);
+          expect(
+            message,
+            isA<DataStreamMessage>()
+                .having((p0) => p0.bytes, 'Same sent data above', [42]),
+          );
+
           cancelDone.complete();
 
           await endDone.future;
@@ -438,9 +470,9 @@ void main() {
 
         Future serverFun() async {
           serverWriter.writeSettingsFrame([]);
-          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
           serverWriter.writeSettingsAckFrame();
-          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
 
           handshakeCompleter.complete();
 
@@ -459,19 +491,28 @@ void main() {
           // happens to be like that ATM.
 
           // Await stream/connection window update frame.
-          var win = await nextFrame() as WindowUpdateFrame;
-          expect(win.header.streamId, 1);
-          expect(win.windowSizeIncrement, 1);
-          win = await nextFrame() as WindowUpdateFrame;
-          expect(win.header.streamId, 0);
-          expect(win.windowSizeIncrement, 1);
-          win = await nextFrame() as WindowUpdateFrame;
-          expect(win.header.streamId, 0);
-          expect(win.windowSizeIncrement, 1);
+
+          expect(
+              await nextFrame(),
+              isA<WindowUpdateFrame>()
+                  .having((p0) => p0.header.streamId, 'Stream update', 1)
+                  .having((p0) => p0.windowSizeIncrement, 'Windowsize', 1));
+          expect(
+              await nextFrame(),
+              isA<WindowUpdateFrame>()
+                  .having((p0) => p0.header.streamId, 'Connection update', 0)
+                  .having((p0) => p0.windowSizeIncrement, 'Windowsize', 1));
+          expect(
+              await nextFrame(),
+              isA<WindowUpdateFrame>()
+                  .having((p0) => p0.header.streamId, 'Connection update', 0)
+                  .having((p0) => p0.windowSizeIncrement, 'Windowsize', 1));
 
           await clientDone.future;
-          var finFrame = await nextFrame() as DataFrame;
-          expect(finFrame.hasEndStreamFlag, true);
+          expect(
+              await nextFrame(),
+              isA<DataFrame>().having(
+                  (p0) => p0.hasEndStreamFlag, 'Last data frame', true));
 
           // Wait for the client finish.
           expect(await serverReader.moveNext(), false);
@@ -485,7 +526,12 @@ void main() {
 
           // first will cancel the stream
           var message = await stream.incomingMessages.first;
-          expect((message as DataStreamMessage).bytes, [42]);
+          expect(
+            message,
+            isA<DataStreamMessage>()
+                .having((p0) => p0.bytes, 'Same sent data above', [42]),
+          );
+
           cancelDone.complete();
 
           await endDone.future;
@@ -508,15 +554,17 @@ void main() {
 
         Future serverFun() async {
           serverWriter.writeSettingsFrame([]);
-          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
           serverWriter.writeSettingsAckFrame();
-          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
 
           handshakeCompleter.complete();
 
           var headers = await nextFrame() as HeadersFrame;
-          var finFrame = await nextFrame() as DataFrame;
-          expect(finFrame.hasEndStreamFlag, true);
+          expect(
+              await nextFrame(),
+              isA<DataFrame>().having(
+                  (p0) => p0.hasEndStreamFlag, 'Last data frame', true));
 
           var streamId = headers.header.streamId;
 
@@ -544,8 +592,13 @@ void main() {
           await stream.outgoingMessages.close();
           var messages = await stream.incomingMessages.toList();
           expect(messages, hasLength(1));
-          expect((messages[0] as HeadersStreamMessage).headers.first,
-              isHeader('a', 'b'));
+
+          expect(
+            messages[0],
+            isA<HeadersStreamMessage>().having((p0) => p0.headers.first,
+                'Same sent headers above', isHeader('a', 'b')),
+          );
+
           await client.finish();
         }
 
@@ -561,9 +614,9 @@ void main() {
 
         Future serverFun() async {
           serverWriter.writeSettingsFrame([]);
-          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
           serverWriter.writeSettingsAckFrame();
-          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
 
           handshakeCompleter.complete();
 
@@ -612,9 +665,9 @@ void main() {
 
         Future serverFun() async {
           serverWriter.writeSettingsFrame([]);
-          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
           serverWriter.writeSettingsAckFrame();
-          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
 
           handshakeCompleter.complete();
 
@@ -671,9 +724,9 @@ void main() {
           var decoder = HPackDecoder();
 
           serverWriter.writeSettingsFrame([]);
-          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
           serverWriter.writeSettingsAckFrame();
-          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
 
           settingsDone.complete();
 
@@ -687,12 +740,16 @@ void main() {
           headersDone.complete();
 
           // Make sure we got the stream reset.
-          var frame2 = await nextFrame() as RstStreamFrame;
-          expect(frame2.errorCode, ErrorCode.CANCEL);
+          expect(
+              await nextFrame(),
+              isA<RstStreamFrame>().having(
+                  (p0) => p0.errorCode, 'Stream reset', ErrorCode.CANCEL));
 
           // Make sure we get the graceful shutdown message.
-          var frame3 = await nextFrame() as GoawayFrame;
-          expect(frame3.errorCode, ErrorCode.NO_ERROR);
+          expect(
+              await nextFrame(),
+              isA<GoawayFrame>().having(
+                  (p0) => p0.errorCode, 'Stream reset', ErrorCode.NO_ERROR));
 
           // Make sure the client ended the connection.
           expect(await serverReader.moveNext(), false);
@@ -730,9 +787,9 @@ void main() {
           var decoder = HPackDecoder();
 
           serverWriter.writeSettingsFrame([]);
-          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
           serverWriter.writeSettingsAckFrame();
-          expect(await nextFrame() is SettingsFrame, true);
+          expect(await nextFrame(), isA<SettingsFrame>());
 
           settingsDone.complete();
 

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -239,7 +239,8 @@ void main() {
           serverWriter.writeDataFrame(invalidStreamId, [42]);
 
           // Make sure the client sends a [RstStreamFrame] frame.
-          expect(await nextFrame() is WindowUpdateFrame, true);
+          var windowUpdateFrame = await nextFrame() as WindowUpdateFrame;
+          expect(windowUpdateFrame.header.streamId, 0);
           expect(
               await nextFrame(),
               isA<RstStreamFrame>()

--- a/test/server_test.dart
+++ b/test/server_test.dart
@@ -92,6 +92,8 @@ void main() {
           clientWriter.writeDataFrame(3, [1, 2, 3]);
 
           // Make sure the client gets a [RstStreamFrame] frame.
+          var frame = await nextFrame();
+          expect(frame is WindowUpdateFrame, true);
           expect(
               await nextFrame(),
               isA<RstStreamFrame>()

--- a/test/src/flowcontrol/connection_queues_test.dart
+++ b/test/src/flowcontrol/connection_queues_test.dart
@@ -155,7 +155,7 @@ void main() {
       var header = FrameHeader(0, 0, 0, STREAM_ID);
       queue.processIgnoredDataFrame(DataFrame(header, 0, bytes));
       expect(queue.pendingMessages, 0);
-      verify(windowMock.gotData(bytes.length)).called(1);
+      verify(windowMock.dataProcessed(bytes.length)).called(1);
       verifyNoMoreInteractions(windowMock);
     });
   });


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dart/issues/624 and #97.

Until now, closed streams generally did not respond to `DATA` frames, which could lead to a mismatch between the window size for client and server on the connection. This is fixed by sending `WINDOW_UPDATE` on receiving such data. I believe this is in line with the spec; but I may be wrong. If sending a `WINDOW_UPDATE` is not allowed, then the client should at least factor in the sent data into the connection window size, and check that the connection is large enough when requesting data on other streams.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
  
