### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.0-dev
+## 2.1.1-wip
 
 - Transform headers to lowercase.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http2
-version: 2.1.0-dev
+version: 2.1.1-wip
 description: A HTTP/2 implementation in Dart.
 repository: https://github.com/dart-lang/http2
 


### PR DESCRIPTION
Avoid multiple changelog entries with the same version. Bump the patch
version for a bug fix. Switch from `-dev` to `-wip` to match updated
patterns for the Dart team.
