### PR TITLE
Expose pings to connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.1.1-wip
 
 - Transform headers to lowercase.
+- Expose pings to connection to enable the KEEPALIVE feature for gRPC.
 
 ## 2.1.0
 

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -99,6 +99,8 @@ abstract class Connection {
 
   final Completer<void> _onInitialPeerSettingsReceived = Completer<void>();
 
+  final StreamController<void> _pingReceived = StreamController<void>();
+
   /// Future which completes when the first SETTINGS frame is received from
   /// the peer.
   Future<void> get onInitialPeerSettingsReceived =>
@@ -179,7 +181,7 @@ abstract class Connection {
     // Setup handlers.
     _settingsHandler = SettingsHandler(_hpackContext.encoder, _frameWriter,
         acknowledgedSettings, peerSettings);
-    _pingHandler = PingHandler(_frameWriter);
+    _pingHandler = PingHandler(_frameWriter, _pingReceived.sink);
 
     var settings = _decodeSettings(settingsObject);
 
@@ -473,6 +475,9 @@ class ClientConnection extends Connection implements ClientTransportConnection {
     }
     return hStream;
   }
+
+  @override
+  Stream<void> get onPingReceived => _pingReceived.stream;
 }
 
 class ServerConnection extends Connection implements ServerTransportConnection {
@@ -489,4 +494,7 @@ class ServerConnection extends Connection implements ServerTransportConnection {
   @override
   Stream<ServerTransportStream> get incomingStreams =>
       _streams.incomingStreams.cast<ServerTransportStream>();
+
+  @override
+  Stream<void> get onPingReceived => _pingReceived.stream;
 }

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -101,6 +101,8 @@ abstract class Connection {
 
   final StreamController<void> _pingReceived = StreamController<void>();
 
+  final StreamController<void> _receivedFrame = StreamController<void>();
+
   /// Future which completes when the first SETTINGS frame is received from
   /// the peer.
   Future<void> get onInitialPeerSettingsReceived =>
@@ -342,6 +344,7 @@ abstract class Connection {
       frame.decodedHeaders =
           _hpackContext.decoder.decode(frame.headerBlockFragment);
     }
+    _receivedFrame.add(null);
 
     // Handle the frame as either a connection or a stream frame.
     if (frame.header.streamId == 0) {
@@ -478,6 +481,9 @@ class ClientConnection extends Connection implements ClientTransportConnection {
 
   @override
   Stream<void> get onPingReceived => _pingReceived.stream;
+
+  @override
+  Stream<void> get onFrameReceived => _receivedFrame.stream;
 }
 
 class ServerConnection extends Connection implements ServerTransportConnection {
@@ -497,4 +503,7 @@ class ServerConnection extends Connection implements ServerTransportConnection {
 
   @override
   Stream<void> get onPingReceived => _pingReceived.stream;
+
+  @override
+  Stream<void> get onFrameReceived => _receivedFrame.stream;
 }

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -99,7 +99,7 @@ abstract class Connection {
 
   final Completer<void> _onInitialPeerSettingsReceived = Completer<void>();
 
-  final StreamController<void> _pingReceived = StreamController<void>();
+  final StreamController<int> _pingReceived = StreamController<int>();
 
   final StreamController<void> _receivedFrame = StreamController<void>();
 
@@ -480,7 +480,7 @@ class ClientConnection extends Connection implements ClientTransportConnection {
   }
 
   @override
-  Stream<void> get onPingReceived => _pingReceived.stream;
+  Stream<int> get onPingReceived => _pingReceived.stream;
 
   @override
   Stream<void> get onFrameReceived => _receivedFrame.stream;
@@ -502,7 +502,7 @@ class ServerConnection extends Connection implements ServerTransportConnection {
       _streams.incomingStreams.cast<ServerTransportStream>();
 
   @override
-  Stream<void> get onPingReceived => _pingReceived.stream;
+  Stream<int> get onPingReceived => _pingReceived.stream;
 
   @override
   Stream<void> get onFrameReceived => _receivedFrame.stream;

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -288,8 +288,8 @@ abstract class Connection {
   }
 
   /// Terminates this connection forcefully.
-  Future terminate() {
-    return _terminate(ErrorCode.NO_ERROR);
+  Future terminate([int? errorCode]) {
+    return _terminate(errorCode ?? ErrorCode.NO_ERROR);
   }
 
   void _activeStateHandler(bool isActive) =>

--- a/lib/src/ping/ping_handler.dart
+++ b/lib/src/ping/ping_handler.dart
@@ -16,9 +16,10 @@ import '../sync_errors.dart';
 class PingHandler extends Object with TerminatableMixin {
   final FrameWriter _frameWriter;
   final Map<int, Completer> _remainingPings = {};
+  final Sink<void>? pingReceived;
   int _nextId = 1;
 
-  PingHandler(this._frameWriter);
+  PingHandler(this._frameWriter, [this.pingReceived]);
 
   @override
   void onTerminated(Object? error) {
@@ -36,6 +37,7 @@ class PingHandler extends Object with TerminatableMixin {
       }
 
       if (!frame.hasAckFlag) {
+        pingReceived?.add(null);
         _frameWriter.writePingFrame(frame.opaqueData, ack: true);
       } else {
         var c = _remainingPings.remove(frame.opaqueData);

--- a/lib/src/ping/ping_handler.dart
+++ b/lib/src/ping/ping_handler.dart
@@ -16,7 +16,7 @@ import '../sync_errors.dart';
 class PingHandler extends Object with TerminatableMixin {
   final FrameWriter _frameWriter;
   final Map<int, Completer> _remainingPings = {};
-  final Sink<void>? pingReceived;
+  final Sink<int>? pingReceived;
   int _nextId = 1;
 
   PingHandler(this._frameWriter, [this.pingReceived]);
@@ -37,7 +37,7 @@ class PingHandler extends Object with TerminatableMixin {
       }
 
       if (!frame.hasAckFlag) {
-        pingReceived?.add(null);
+        pingReceived?.add(frame.opaqueData);
         _frameWriter.writePingFrame(frame.opaqueData, ack: true);
       } else {
         var c = _remainingPings.remove(frame.opaqueData);

--- a/lib/transport.dart
+++ b/lib/transport.dart
@@ -64,8 +64,8 @@ abstract class TransportConnection {
   /// the peer.
   Future<void> get onInitialPeerSettingsReceived;
 
-  /// Future which completes when the first SETTINGS frame is received from
-  /// the peer.
+  /// Stream which emits an event every time a ping is received on this
+  /// connection.
   Stream<void> get onPingReceived;
 
   /// Finish this connection.

--- a/lib/transport.dart
+++ b/lib/transport.dart
@@ -68,6 +68,10 @@ abstract class TransportConnection {
   /// connection.
   Stream<void> get onPingReceived;
 
+  /// Stream which emits an event every time a ping is received on this
+  /// connection.
+  Stream<void> get onFrameReceived;
+
   /// Finish this connection.
   ///
   /// No new streams will be accepted or can be created.

--- a/lib/transport.dart
+++ b/lib/transport.dart
@@ -9,6 +9,7 @@ import 'src/connection.dart';
 import 'src/hpack/hpack.dart' show Header;
 
 export 'src/hpack/hpack.dart' show Header;
+export 'src/frames/frames.dart' show ErrorCode;
 
 typedef ActiveStateHandler = void Function(bool isActive);
 
@@ -78,7 +79,7 @@ abstract class TransportConnection {
   Future finish();
 
   /// Terminates this connection forcefully.
-  Future terminate();
+  Future terminate([int? errorCode]);
 }
 
 abstract class ClientTransportConnection extends TransportConnection {

--- a/lib/transport.dart
+++ b/lib/transport.dart
@@ -64,6 +64,10 @@ abstract class TransportConnection {
   /// the peer.
   Future<void> get onInitialPeerSettingsReceived;
 
+  /// Future which completes when the first SETTINGS frame is received from
+  /// the peer.
+  Stream<void> get onPingReceived;
+
   /// Finish this connection.
   ///
   /// No new streams will be accepted or can be created.

--- a/lib/transport.dart
+++ b/lib/transport.dart
@@ -65,9 +65,9 @@ abstract class TransportConnection {
   /// the peer.
   Future<void> get onInitialPeerSettingsReceived;
 
-  /// Stream which emits an event every time a ping is received on this
-  /// connection.
-  Stream<void> get onPingReceived;
+  /// Stream which emits an event with the ping id every time a ping is received
+  /// on this connection.
+  Stream<int> get onPingReceived;
 
   /// Stream which emits an event every time a ping is received on this
   /// connection.

--- a/test/src/ping/ping_handler_test.dart
+++ b/test/src/ping/ping_handler_test.dart
@@ -103,7 +103,7 @@ void main() {
       pingHandler.processPingFrame(PingFrame(header, 1));
       var header2 = FrameHeader(8, FrameType.PING, 0, 0);
       pingHandler.processPingFrame(PingFrame(header2, 2));
-      await expectLater(streamController.stream, emitsInOrder([null, null]));
+      await expectLater(streamController.stream, emitsInOrder([1, 2]));
     });
   });
 }

--- a/test/src/ping/ping_handler_test.dart
+++ b/test/src/ping/ping_handler_test.dart
@@ -93,6 +93,18 @@ void main() {
           throwsA(isProtocolException));
       verifyZeroInteractions(writer);
     });
+
+    test('receiving-ping-calls-stream', () async {
+      var writer = FrameWriterMock();
+      var streamController = StreamController();
+      var pingHandler = PingHandler(writer, streamController.sink);
+
+      var header = FrameHeader(8, FrameType.PING, 0, 0);
+      pingHandler.processPingFrame(PingFrame(header, 1));
+      var header2 = FrameHeader(8, FrameType.PING, 0, 0);
+      pingHandler.processPingFrame(PingFrame(header2, 2));
+      await expectLater(streamController.stream, emitsInOrder([null, null]));
+    });
   });
 }
 

--- a/test/src/ping/ping_handler_test.dart
+++ b/test/src/ping/ping_handler_test.dart
@@ -96,7 +96,7 @@ void main() {
 
     test('receiving-ping-calls-stream', () async {
       var writer = FrameWriterMock();
-      var streamController = StreamController();
+      var streamController = StreamController<int>();
       var pingHandler = PingHandler(writer, streamController.sink);
 
       var header = FrameHeader(8, FrameType.PING, 0, 0);


### PR DESCRIPTION
To make https://github.com/grpc/grpc-dart/pull/634 possible, expose to the connection whenever a ping is received.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
