### PR TITLE
Add `topics` to package "http2" `pubspec.yaml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.3.1-wip
 
 - Require Dart 3.2
+- Add topics to `pubspec.yaml`
 
 ## 2.3.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,6 +3,11 @@ version: 2.3.1-wip
 description: A HTTP/2 implementation in Dart.
 repository: https://github.com/dart-lang/http2
 
+topics:
+ - http
+ - network
+ - protocols
+
 environment:
   sdk: ^3.2.0
 


### PR DESCRIPTION
Topics help users on pub.dev discover packages, and related packages.

You can see a list of [topics here](https://pub.dev/topics).
You can also make your own topics.

Topics are added to pubspec.yaml as follows:
```
topics:
 - my-topic
 - some-other-topic
 ```
See also: https://dart.dev/tools/pub/pubspec#topics